### PR TITLE
Parameterized IRC nicknames

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -35,7 +35,8 @@ auth_ldap:
 
 # IRC channels to report to
 irc:
-    nickname: "pushhamster"
+    # nickname can be parameterized with syntax like a python format string
+    nickname: "pushhamster|{pushmaster}"
     channel: "push"
 
 mail:

--- a/servlets/msg.py
+++ b/servlets/msg.py
@@ -14,11 +14,13 @@ class MsgServlet(RequestHandler):
         if not message:
             return self.send_error(500)
 
+        irc_nick = Settings['irc']['nickname'].format(pushmaster=self.current_user)
+
         irc_message = '%s: %s' % (', '.join(people), message) if people else message
         subprocess.call([
                 '/nail/sys/bin/nodebot',
                 '-i',
-                Settings['irc']['nickname'],
+                irc_nick,
                 Settings['irc']['channel'],
                 irc_message
         ])


### PR DESCRIPTION
This allows the IRC nick used to send announcements to be parameterized with the current pushmaster's username. This should make it easier to identify who is running pushes and when.
