### PR TITLE
Adds scheme, port, and auth features to pushmanager SHA lookup

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -66,6 +66,9 @@ trac:
     servername: trac.example.com
 
 git:
+    scheme: "git"
+    auth: ""
+    port: ""
     servername: "git.example.com"
     gitweb_servername: "gitweb.example.com"
     main_repository: "main-repository"

--- a/tests/test_core_git.py
+++ b/tests/test_core_git.py
@@ -76,7 +76,7 @@ class CoreGitTest(T.TestCase):
           "main_repository": "main_repository", 
           "dev_repositories_dir": "dev_directory"
         }
-	with mock.patch.dict(Settings, T.MockedSettings):
+        with mock.patch.dict(Settings, T.MockedSettings):
             T.assert_equal(core.git.GitQueue._get_repository_uri("main_repository"),
               "git://example/main_repository")
             T.assert_equal(core.git.GitQueue._get_repository_uri("second_repository"),


### PR DESCRIPTION
Minimal change that generalizes SHA lookup by adding the ability to use more than just anonymous git:// access. Adds the appropriate tests as well, though more may be desired.
