### PR TITLE
Fixes a clerical error in #7: "self" should be "cls"

### DIFF
--- a/core/git.py
+++ b/core/git.py
@@ -69,7 +69,7 @@ class GitQueue(object):
     @classmethod
     def _get_branch_sha_from_repo(cls, req):
         user_to_notify = req['user']
-        repository = self._get_repository_uri(req['repo'])
+        repository = cls._get_repository_uri(req['repo'])
         ls_remote = GitCommand('ls-remote', '-h', repository, req['branch'])
         rc, stdout, stderr = ls_remote.run()
         stdout = stdout.strip()


### PR DESCRIPTION
Fairly self-explanatory: I botched an invocation of `self` in #7 that got covered over by mocks during testing.

Fixes master. We should consider more deeply testing the function I broke in the future, but patches things up for now.
