### PR TITLE
Add new pushplans tag

### DIFF
--- a/servlets/checklist.py
+++ b/servlets/checklist.py
@@ -9,6 +9,7 @@ import core.util
 
 checklist_reminders = {
     'plans': dict((target, 'Plans for %(pushee)s') for target in ('stage', 'prod')),
+    'pushplans': dict((target, 'Push plans for %(pushee)s') for target in ('stage', 'prod')),
     'search': {
         'post-stage': 'Restart stage search for %(pushee)s',
         'prod': 'Disable index distribution for %(pushee)s',
@@ -22,6 +23,9 @@ checklist_reminders = {
     },
     'plans-cleanup': {
         'post-verify-stage': 'Run plans on other stages for %(pushee)s',
+    },
+    'pushplans-cleanup': {
+        'post-verify-stage': 'Run push plans on other stages for %(pushee)s',
     },
     'search-cleanup': {
         'post-verify-prod': 'Re-enable index distribution in prod for %(pushee)s',
@@ -80,6 +84,8 @@ class ChecklistServlet(RequestHandler):
             merge_items = defaultdict(list)
             for item in items:
                 if item['type'] == "plans":
+                    clean_items_by_target[target].append(item)
+                elif item['type'] == "pushplans":
                     clean_items_by_target[target].append(item)
                 else:
                     merge_items[item['type']].append(item)

--- a/servlets/newrequest.py
+++ b/servlets/newrequest.py
@@ -83,6 +83,8 @@ class NewRequestServlet(RequestHandler):
 
         if 'plans' in self.tag_list:
             necessary_checklist_types.add('plans')
+        if 'pushplans' in self.tag_list:
+            necessary_checklist_types.add('pushplans')
         if 'search-backend' in self.tag_list:
             necessary_checklist_types.add('search')
         if 'hoods' in self.tag_list:
@@ -94,11 +96,14 @@ class NewRequestServlet(RequestHandler):
         # Different types of checklist items need to happen at different points.
         targets_by_type = {
             'plans' : ('stage', 'prod'),
+            'pushplans' : ('stage', 'prod'),
             'search' : ('post-stage', 'prod', 'post-prod', 'post-verify'),
             'hoods' : ('stage', 'post-stage', 'prod'),
             # We need to append checklist items to clean up after
             # plans & search checklist items.
             'plans-cleanup' : ('post-verify-stage',),
+            # push plans & search checklist items.
+            'pushplans-cleanup' : ('post-verify-stage',),
             'search-cleanup': ('post-verify-prod',),
             'hoods-cleanup' : ('post-verify-stage',),
         }

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -714,6 +714,7 @@ ul.tags > .tag-special	{ background: #fcf; }
 ul.tags > .tag-caches		{ background: #ff8; }
 ul.tags > .tag-buildbot	{ background: #de9; }
 ul.tags > .tag-plans		{ background: #ccf; }
+ul.tags > .tag-pushplans	{ background: #ccf; }
 ul.tags > .tag-git-ok		{ background: #fec; }
 ul.tags > .tag-git-error	{ background: #f00; }
 ul.tags > .tag-accepting	{ background: #ddf; }

--- a/templates/modules/newrequest.html
+++ b/templates/modules/newrequest.html
@@ -17,7 +17,7 @@
 		&mdash;
 		<span class="tag-suggestion" title="This push request's branch has been tested on Buildbot.">buildbot</span>
 		<span class="tag-suggestion" title="This push request invalidates one or more caches.">caches</span>
-		<span class="tag-suggestion" title="This push request involves push plans.">plans</span>
+		<span class="tag-suggestion" title="This push request involves push plans.">pushplans</span>
 		<span class="tag-suggestion" title="This push request needs special handling - the pushmaster should talk to the requestor before pushing it.">special</span>
 		<span class="tag-suggestion" title="This push request is urgent (p0).">urgent</span>
 		<span class="tag-suggestion" title="This push request involves changes to the search backend and should be coordinated with a member of the Search team.">search-backend</span>

--- a/ui_modules.py
+++ b/ui_modules.py
@@ -75,6 +75,13 @@ class Request(UIModule):
                 request['branch']
             )
 
+        if 'pushplans' in tags:
+            tags['pushplans'] = "https://%s/?p=%s.git;a=history;f=pushplans;hb=refs/heads/%s" % (
+                Settings['git']['gitweb_servername'],
+                repo,
+                request['branch']
+            )
+
         return sorted(tags.iteritems())
 
 class NewRequestDialog(UIModule):


### PR DESCRIPTION
Push plans is the new tag that will replace plans
The plans tag has become ambiguous with the introduction of test plans

This PR is backwards compatibile with existing pull requests that still have the plans tag. All new requests show a Quick Tag of pushplans instead of plans, so eventually, all requests should have pushplans.

To remove backwards compatibility, the database should be scrubbed of tags containing the plans tag and then all plans tag code can then be removed safely.
