### PR TITLE
Replace plans with pushplans

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -18,8 +18,7 @@ def UnsignedInteger():
 
 
 class DatabaseError(Exception):
-	def __init__(self, *args, **kwargs):
-		Exception.__init__(self, 'A database error has occured')
+    pass
 
 
 class PushCheckList(Base):

--- a/core/db.py
+++ b/core/db.py
@@ -16,6 +16,12 @@ def UnsignedInteger():
     else:
         return Integer
 
+
+class DatabaseError(Exception):
+	def __init__(self, *args, **kwargs):
+		Exception.__init__(self, 'A database error has occured')
+
+
 class PushCheckList(Base):
     __tablename__ = "push_checklist"
 

--- a/pushplans/rename_push_to_pushplan.py
+++ b/pushplans/rename_push_to_pushplan.py
@@ -1,0 +1,17 @@
+#!/bin/sh
+############################################################
+# Convert plans to pushplans
+#
+# Run as PYTHONPATH=. sh pushplans/rename_push_to_pushplan.py
+# from pushmanager root
+############################################################
+SCRIPT=$(readlink -f $0)
+SCRIPT_DIR=$(dirname $SCRIPT)
+echo $SCRIPT_DIR
+
+python -u "${SCRIPT_DIR}/../tools/rename_tag.py" plans pushplans
+python -u "${SCRIPT_DIR}/../tools/rename_checklist_type.py" plans pushplans
+
+# Revert steps if needed
+#python -u "${SCRIPT_DIR}/../tools/rename_tag.py" pushplans plans
+#python -u "${SCRIPT_DIR}/../tools/rename_checklist_type.py" pushplans plans

--- a/servlets/checklist.py
+++ b/servlets/checklist.py
@@ -9,6 +9,7 @@ import core.util
 
 checklist_reminders = {
     'plans': dict((target, 'Plans for %(pushee)s') for target in ('stage', 'prod')),
+    'pushplans': dict((target, 'Push plans for %(pushee)s') for target in ('stage', 'prod')),
     'search': {
         'post-stage': 'Restart stage search for %(pushee)s',
         'prod': 'Disable index distribution for %(pushee)s',
@@ -22,6 +23,9 @@ checklist_reminders = {
     },
     'plans-cleanup': {
         'post-verify-stage': 'Run plans on other stages for %(pushee)s',
+    },
+    'pushplans-cleanup': {
+        'post-verify-stage': 'Run push plans on other stages for %(pushee)s',
     },
     'search-cleanup': {
         'post-verify-prod': 'Re-enable index distribution in prod for %(pushee)s',
@@ -80,6 +84,8 @@ class ChecklistServlet(RequestHandler):
             merge_items = defaultdict(list)
             for item in items:
                 if item['type'] == "plans":
+                    clean_items_by_target[target].append(item)
+                elif item['type'] == "pushplans":
                     clean_items_by_target[target].append(item)
                 else:
                     merge_items[item['type']].append(item)

--- a/servlets/checklist.py
+++ b/servlets/checklist.py
@@ -8,7 +8,6 @@ import core.util
 
 
 checklist_reminders = {
-    'plans': dict((target, 'Plans for %(pushee)s') for target in ('stage', 'prod')),
     'pushplans': dict((target, 'Push plans for %(pushee)s') for target in ('stage', 'prod')),
     'search': {
         'post-stage': 'Restart stage search for %(pushee)s',
@@ -20,9 +19,6 @@ checklist_reminders = {
         'stage': 'Notify %(pushee)s to deploy Geoservices to stage.',
         'post-stage': 'Ask Search to force index distribution on stage for %(pushee)s',
         'prod': 'Notify %(pushee)s to deploy Geoservices to prod.',
-    },
-    'plans-cleanup': {
-        'post-verify-stage': 'Run plans on other stages for %(pushee)s',
     },
     'pushplans-cleanup': {
         'post-verify-stage': 'Run push plans on other stages for %(pushee)s',
@@ -83,9 +79,7 @@ class ChecklistServlet(RequestHandler):
         for target, items in items_by_target.items():
             merge_items = defaultdict(list)
             for item in items:
-                if item['type'] == "plans":
-                    clean_items_by_target[target].append(item)
-                elif item['type'] == "pushplans":
+                if item['type'] == "pushplans":
                     clean_items_by_target[target].append(item)
                 else:
                     merge_items[item['type']].append(item)

--- a/servlets/newrequest.py
+++ b/servlets/newrequest.py
@@ -81,8 +81,6 @@ class NewRequestServlet(RequestHandler):
 
         necessary_checklist_types = set()
 
-        if 'plans' in self.tag_list:
-            necessary_checklist_types.add('plans')
         if 'pushplans' in self.tag_list:
             necessary_checklist_types.add('pushplans')
         if 'search-backend' in self.tag_list:
@@ -95,13 +93,10 @@ class NewRequestServlet(RequestHandler):
 
         # Different types of checklist items need to happen at different points.
         targets_by_type = {
-            'plans' : ('stage', 'prod'),
             'pushplans' : ('stage', 'prod'),
             'search' : ('post-stage', 'prod', 'post-prod', 'post-verify'),
             'hoods' : ('stage', 'post-stage', 'prod'),
             # We need to append checklist items to clean up after
-            # plans & search checklist items.
-            'plans-cleanup' : ('post-verify-stage',),
             # push plans & search checklist items.
             'pushplans-cleanup' : ('post-verify-stage',),
             'search-cleanup': ('post-verify-prod',),

--- a/servlets/newrequest.py
+++ b/servlets/newrequest.py
@@ -83,6 +83,8 @@ class NewRequestServlet(RequestHandler):
 
         if 'plans' in self.tag_list:
             necessary_checklist_types.add('plans')
+        if 'pushplans' in self.tag_list:
+            necessary_checklist_types.add('pushplans')
         if 'search-backend' in self.tag_list:
             necessary_checklist_types.add('search')
         if 'hoods' in self.tag_list:
@@ -94,11 +96,14 @@ class NewRequestServlet(RequestHandler):
         # Different types of checklist items need to happen at different points.
         targets_by_type = {
             'plans' : ('stage', 'prod'),
+            'pushplans' : ('stage', 'prod'),
             'search' : ('post-stage', 'prod', 'post-prod', 'post-verify'),
             'hoods' : ('stage', 'post-stage', 'prod'),
             # We need to append checklist items to clean up after
             # plans & search checklist items.
             'plans-cleanup' : ('post-verify-stage',),
+            # push plans & search checklist items.
+            'pushplans-cleanup' : ('post-verify-stage',),
             'search-cleanup': ('post-verify-prod',),
             'hoods-cleanup' : ('post-verify-stage',),
         }

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -714,6 +714,7 @@ ul.tags > .tag-special	{ background: #fcf; }
 ul.tags > .tag-caches		{ background: #ff8; }
 ul.tags > .tag-buildbot	{ background: #de9; }
 ul.tags > .tag-plans		{ background: #ccf; }
+ul.tags > .tag-pushplans	{ background: #ccf; }
 ul.tags > .tag-git-ok		{ background: #fec; }
 ul.tags > .tag-git-error	{ background: #f00; }
 ul.tags > .tag-accepting	{ background: #ddf; }

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -713,7 +713,6 @@ ul.tags > .tag-urgent		{ background: #fcc; }
 ul.tags > .tag-special	{ background: #fcf; }
 ul.tags > .tag-caches		{ background: #ff8; }
 ul.tags > .tag-buildbot	{ background: #de9; }
-ul.tags > .tag-plans		{ background: #ccf; }
 ul.tags > .tag-pushplans	{ background: #ccf; }
 ul.tags > .tag-git-ok		{ background: #fec; }
 ul.tags > .tag-git-error	{ background: #f00; }

--- a/templates/modules/newrequest.html
+++ b/templates/modules/newrequest.html
@@ -17,7 +17,7 @@
 		&mdash;
 		<span class="tag-suggestion" title="This push request's branch has been tested on Buildbot.">buildbot</span>
 		<span class="tag-suggestion" title="This push request invalidates one or more caches.">caches</span>
-		<span class="tag-suggestion" title="This push request involves push plans.">plans</span>
+		<span class="tag-suggestion" title="This push request involves push plans.">pushplans</span>
 		<span class="tag-suggestion" title="This push request needs special handling - the pushmaster should talk to the requestor before pushing it.">special</span>
 		<span class="tag-suggestion" title="This push request is urgent (p0).">urgent</span>
 		<span class="tag-suggestion" title="This push request involves changes to the search backend and should be coordinated with a member of the Search team.">search-backend</span>

--- a/tests/test_rename_checklist_type.py
+++ b/tests/test_rename_checklist_type.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from functools import partial
+import os
+
+from mock import patch
+
+from core import db
+from tools import rename_checklist_type
+import testing as T
+
+
+class RenameTagTest(T.TestCase, T.FakeDataMixin):
+
+	checklist_keys = [ 'id', 'request', 'type', 'complete', 'target']
+
+	checklist_data = [
+		[1, 0, 'search', 0, 'stage'],
+		[2, 0, 'search', 0, 'prod'],
+		[3, 0, 'search-cleanup', 0, 'post-stage-verify'],
+		[4, 0, 'plans', 0, 'stage'],
+		[5, 0, 'plans-cleanup', 0, 'prod']
+	]
+
+	@T.setup_teardown
+	def setup_db(self):
+		self.db_file_path = T.testdb.create_temp_db_file()
+		T.MockedSettings['db_uri'] = T.testdb.get_temp_db_uri(self.db_file_path)
+		with patch.dict(db.Settings, T.MockedSettings):
+			db.init_db()
+			self.insert_checklists()
+			yield
+			db.finalize_db()
+			os.unlink(self.db_file_path)
+
+	def check_db_results(self, success, db_results):
+		if not success:
+			raise db.DatabaseError()
+
+	def verify_database_state(self, data, success, db_results):
+		self.check_db_results(success, db_results)
+
+		# id, push, *type*, status, target
+		data_types = [d[2] for d in data]
+		# id, push, *type*, status, target
+		types = [result[2] for result in db_results.fetchall()]
+
+		T.assert_sorted_equal(data_types, types)
+
+	def verify_type_rename(self, oldtype, newtype, success, db_results):
+		self.check_db_results(success, db_results)
+
+		# id, push, *type*, status, target
+		types = [result[2] for result in db_results.fetchall()]
+
+		T.assert_not_in(oldtype, types)
+		T.assert_not_in('%s-cleanup' % oldtype, types)
+		T.assert_in('%s' % newtype, types)
+		T.assert_in('%s-cleanup' % newtype, types)
+
+	def make_checklist_dict(self, data):
+		return dict(zip(self.checklist_keys, data))
+
+	def insert_checklists(self):
+		checklist_queries = []
+		for cl in self.checklist_data:
+			checklist_queries.append(db.push_checklist.insert(self.make_checklist_dict(cl)))
+		db.execute_transaction_cb(checklist_queries, self.on_db_return)
+
+	@patch('tools.rename_checklist_type.convert_checklist')
+	@patch('optparse.OptionParser.error')
+	@patch('optparse.OptionParser.parse_args', return_value=[None, []])
+	def test_main_noargs(self, parser, error, convert_checklist):
+		rename_checklist_type.main()
+		T.assert_equal(False, convert_checklist.called)
+		error.assert_called_once_with('Incorrect number of arguments')
+
+	@patch('tools.rename_checklist_type.convert_checklist')
+	@patch('optparse.OptionParser.error')
+	@patch('optparse.OptionParser.parse_args',
+			return_value=[None, ['oldtag', 'newtag']])
+	def test_main_twoargs(self, parser, error, convert_checklist):
+		parser.return_value=[None, ['oldtag', 'newtag']]
+		rename_checklist_type.main()
+		convert_checklist.assert_called_once_with('oldtag', 'newtag')
+		T.assert_equal(False, error.called)
+
+	def test_convert_cleanup_type(self):
+		rename_checklist_type.convert_checklist('search', 'not_search')
+		cb = partial(self.verify_type_rename, 'search', 'not_search')
+		db.execute_cb(db.push_checklist.select(), cb)
+
+	def test_convert_notype(self):
+		rename_checklist_type.convert_checklist('nonexistent', 'random')
+		cb = partial(self.verify_database_state, self.checklist_data)
+		db.execute_cb(db.push_checklist.select(), cb)
+
+
+
+if __name__ == '__main__':
+	T.run()

--- a/tests/test_rename_checklist_type.py
+++ b/tests/test_rename_checklist_type.py
@@ -11,90 +11,90 @@ import testing as T
 
 class RenameTagTest(T.TestCase, T.FakeDataMixin):
 
-	checklist_keys = [ 'id', 'request', 'type', 'complete', 'target']
+    checklist_keys = [ 'id', 'request', 'type', 'complete', 'target']
 
-	checklist_data = [
-		[1, 0, 'search', 0, 'stage'],
-		[2, 0, 'search', 0, 'prod'],
-		[3, 0, 'search-cleanup', 0, 'post-stage-verify'],
-		[4, 0, 'plans', 0, 'stage'],
-		[5, 0, 'plans-cleanup', 0, 'prod']
-	]
+    checklist_data = [
+        [1, 0, 'search', 0, 'stage'],
+        [2, 0, 'search', 0, 'prod'],
+        [3, 0, 'search-cleanup', 0, 'post-stage-verify'],
+        [4, 0, 'plans', 0, 'stage'],
+        [5, 0, 'plans-cleanup', 0, 'prod']
+    ]
 
-	@T.setup_teardown
-	def setup_db(self):
-		self.db_file_path = T.testdb.create_temp_db_file()
-		T.MockedSettings['db_uri'] = T.testdb.get_temp_db_uri(self.db_file_path)
-		with patch.dict(db.Settings, T.MockedSettings):
-			db.init_db()
-			self.insert_checklists()
-			yield
-			db.finalize_db()
-			os.unlink(self.db_file_path)
+    @T.setup_teardown
+    def setup_db(self):
+        self.db_file_path = T.testdb.create_temp_db_file()
+        T.MockedSettings['db_uri'] = T.testdb.get_temp_db_uri(self.db_file_path)
+        with patch.dict(db.Settings, T.MockedSettings):
+            db.init_db()
+            self.insert_checklists()
+            yield
+            db.finalize_db()
+            os.unlink(self.db_file_path)
 
-	def check_db_results(self, success, db_results):
-		if not success:
-			raise db.DatabaseError()
+    def check_db_results(self, success, db_results):
+        if not success:
+            raise db.DatabaseError()
 
-	def verify_database_state(self, data, success, db_results):
-		self.check_db_results(success, db_results)
+    def verify_database_state(self, data, success, db_results):
+        self.check_db_results(success, db_results)
 
-		# id, push, *type*, status, target
-		data_types = [d[2] for d in data]
-		# id, push, *type*, status, target
-		types = [result[2] for result in db_results.fetchall()]
+        # id, push, *type*, status, target
+        data_types = [d[2] for d in data]
+        # id, push, *type*, status, target
+        types = [result[2] for result in db_results.fetchall()]
 
-		T.assert_sorted_equal(data_types, types)
+        T.assert_sorted_equal(data_types, types)
 
-	def verify_type_rename(self, oldtype, newtype, success, db_results):
-		self.check_db_results(success, db_results)
+    def verify_type_rename(self, oldtype, newtype, success, db_results):
+        self.check_db_results(success, db_results)
 
-		# id, push, *type*, status, target
-		types = [result[2] for result in db_results.fetchall()]
+        # id, push, *type*, status, target
+        types = [result[2] for result in db_results.fetchall()]
 
-		T.assert_not_in(oldtype, types)
-		T.assert_not_in('%s-cleanup' % oldtype, types)
-		T.assert_in('%s' % newtype, types)
-		T.assert_in('%s-cleanup' % newtype, types)
+        T.assert_not_in(oldtype, types)
+        T.assert_not_in('%s-cleanup' % oldtype, types)
+        T.assert_in('%s' % newtype, types)
+        T.assert_in('%s-cleanup' % newtype, types)
 
-	def make_checklist_dict(self, data):
-		return dict(zip(self.checklist_keys, data))
+    def make_checklist_dict(self, data):
+        return dict(zip(self.checklist_keys, data))
 
-	def insert_checklists(self):
-		checklist_queries = []
-		for cl in self.checklist_data:
-			checklist_queries.append(db.push_checklist.insert(self.make_checklist_dict(cl)))
-		db.execute_transaction_cb(checklist_queries, self.on_db_return)
+    def insert_checklists(self):
+        checklist_queries = []
+        for cl in self.checklist_data:
+            checklist_queries.append(db.push_checklist.insert(self.make_checklist_dict(cl)))
+        db.execute_transaction_cb(checklist_queries, self.on_db_return)
 
-	@patch('tools.rename_checklist_type.convert_checklist')
-	@patch('optparse.OptionParser.error')
-	@patch('optparse.OptionParser.parse_args', return_value=[None, []])
-	def test_main_noargs(self, parser, error, convert_checklist):
-		rename_checklist_type.main()
-		T.assert_equal(False, convert_checklist.called)
-		error.assert_called_once_with('Incorrect number of arguments')
+    @patch('tools.rename_checklist_type.convert_checklist')
+    @patch('optparse.OptionParser.error')
+    @patch('optparse.OptionParser.parse_args', return_value=[None, []])
+    def test_main_noargs(self, parser, error, convert_checklist):
+        rename_checklist_type.main()
+        T.assert_equal(False, convert_checklist.called)
+        error.assert_called_once_with('Incorrect number of arguments')
 
-	@patch('tools.rename_checklist_type.convert_checklist')
-	@patch('optparse.OptionParser.error')
-	@patch('optparse.OptionParser.parse_args',
-			return_value=[None, ['oldtag', 'newtag']])
-	def test_main_twoargs(self, parser, error, convert_checklist):
-		parser.return_value=[None, ['oldtag', 'newtag']]
-		rename_checklist_type.main()
-		convert_checklist.assert_called_once_with('oldtag', 'newtag')
-		T.assert_equal(False, error.called)
+    @patch('tools.rename_checklist_type.convert_checklist')
+    @patch('optparse.OptionParser.error')
+    @patch('optparse.OptionParser.parse_args',
+            return_value=[None, ['oldtag', 'newtag']])
+    def test_main_twoargs(self, parser, error, convert_checklist):
+        parser.return_value=[None, ['oldtag', 'newtag']]
+        rename_checklist_type.main()
+        convert_checklist.assert_called_once_with('oldtag', 'newtag')
+        T.assert_equal(False, error.called)
 
-	def test_convert_cleanup_type(self):
-		rename_checklist_type.convert_checklist('search', 'not_search')
-		cb = partial(self.verify_type_rename, 'search', 'not_search')
-		db.execute_cb(db.push_checklist.select(), cb)
+    def test_convert_cleanup_type(self):
+        rename_checklist_type.convert_checklist('search', 'not_search')
+        cb = partial(self.verify_type_rename, 'search', 'not_search')
+        db.execute_cb(db.push_checklist.select(), cb)
 
-	def test_convert_notype(self):
-		rename_checklist_type.convert_checklist('nonexistent', 'random')
-		cb = partial(self.verify_database_state, self.checklist_data)
-		db.execute_cb(db.push_checklist.select(), cb)
+    def test_convert_notype(self):
+        rename_checklist_type.convert_checklist('nonexistent', 'random')
+        cb = partial(self.verify_database_state, self.checklist_data)
+        db.execute_cb(db.push_checklist.select(), cb)
 
 
 
 if __name__ == '__main__':
-	T.run()
+    T.run()

--- a/tests/test_rename_checklist_type.py
+++ b/tests/test_rename_checklist_type.py
@@ -17,8 +17,8 @@ class RenameTagTest(T.TestCase, T.FakeDataMixin):
         [1, 0, 'search', 0, 'stage'],
         [2, 0, 'search', 0, 'prod'],
         [3, 0, 'search-cleanup', 0, 'post-stage-verify'],
-        [4, 0, 'plans', 0, 'stage'],
-        [5, 0, 'plans-cleanup', 0, 'prod']
+        [4, 0, 'pushplans', 0, 'stage'],
+        [5, 0, 'pushplans-cleanup', 0, 'prod']
     ]
 
     @T.setup_teardown

--- a/tests/test_rename_tag.py
+++ b/tests/test_rename_tag.py
@@ -11,68 +11,68 @@ import testing as T
 
 class RenameTagTest(T.TestCase, T.FakeDataMixin):
 
-	@T.setup_teardown
-	def setup_db(self):
-		self.db_file_path = T.testdb.create_temp_db_file()
-		T.MockedSettings['db_uri'] = T.testdb.get_temp_db_uri(self.db_file_path)
-		with patch.dict(db.Settings, T.MockedSettings):
-			db.init_db()
-			self.insert_requests()
-			yield
-			db.finalize_db()
-			os.unlink(self.db_file_path)
+    @T.setup_teardown
+    def setup_db(self):
+        self.db_file_path = T.testdb.create_temp_db_file()
+        T.MockedSettings['db_uri'] = T.testdb.get_temp_db_uri(self.db_file_path)
+        with patch.dict(db.Settings, T.MockedSettings):
+            db.init_db()
+            self.insert_requests()
+            yield
+            db.finalize_db()
+            os.unlink(self.db_file_path)
 
-	def check_db_results(self, success, db_results):
-		if not success:
-			raise db.DatabaseError()
+    def check_db_results(self, success, db_results):
+        if not success:
+            raise db.DatabaseError()
 
-	def verify_database_state(self, data, success, db_results):
-		self.check_db_results(success, db_results)
+    def verify_database_state(self, data, success, db_results):
+        self.check_db_results(success, db_results)
 
-		# id, user, state, repo, branch, *tags*, created, modified, etc...
-		data_tags = [d[5] for d in data]
-		#id, user, state, repo, branch, revision, *tags*, created, etc...
-		tags = [result[6] for result in db_results.fetchall()]
+        # id, user, state, repo, branch, *tags*, created, modified, etc...
+        data_tags = [d[5] for d in data]
+        #id, user, state, repo, branch, revision, *tags*, created, etc...
+        tags = [result[6] for result in db_results.fetchall()]
 
-		T.assert_sorted_equal(data_tags, tags)
+        T.assert_sorted_equal(data_tags, tags)
 
-	def verify_tag_rename(self, oldtag, newtag, success, db_results):
-		self.check_db_results(success, db_results)
+    def verify_tag_rename(self, oldtag, newtag, success, db_results):
+        self.check_db_results(success, db_results)
 
-		#id, user, state, repo, branch, revision, *tags*, created, etc...
-		tags = [result[6] for result in db_results.fetchall()]
+        #id, user, state, repo, branch, revision, *tags*, created, etc...
+        tags = [result[6] for result in db_results.fetchall()]
 
-		T.assert_not_in(oldtag, tags)
-		T.assert_in(newtag, tags)
+        T.assert_not_in(oldtag, tags)
+        T.assert_in(newtag, tags)
 
-	@patch('tools.rename_tag.convert_tag')
-	@patch('optparse.OptionParser.error')
-	@patch('optparse.OptionParser.parse_args', return_value=[None, []])
-	def test_main_noargs(self, parser, error, convert_tag):
-		rename_tag.main()
-		T.assert_equal(False, convert_tag.called)
-		error.assert_called_once_with('Incorrect number of arguments')
+    @patch('tools.rename_tag.convert_tag')
+    @patch('optparse.OptionParser.error')
+    @patch('optparse.OptionParser.parse_args', return_value=[None, []])
+    def test_main_noargs(self, parser, error, convert_tag):
+        rename_tag.main()
+        T.assert_equal(False, convert_tag.called)
+        error.assert_called_once_with('Incorrect number of arguments')
 
-	@patch('tools.rename_tag.convert_tag')
-	@patch('optparse.OptionParser.error')
-	@patch('optparse.OptionParser.parse_args',
-			return_value=[None, ['oldtag', 'newtag']])
-	def test_main_twoargs(self, parser, error, convert_tag):
-		parser.return_value=[None, ['oldtag', 'newtag']]
-		rename_tag.main()
-		convert_tag.assert_called_once_with('oldtag', 'newtag')
-		T.assert_equal(False, error.called)
+    @patch('tools.rename_tag.convert_tag')
+    @patch('optparse.OptionParser.error')
+    @patch('optparse.OptionParser.parse_args',
+            return_value=[None, ['oldtag', 'newtag']])
+    def test_main_twoargs(self, parser, error, convert_tag):
+        parser.return_value=[None, ['oldtag', 'newtag']]
+        rename_tag.main()
+        convert_tag.assert_called_once_with('oldtag', 'newtag')
+        T.assert_equal(False, error.called)
 
-	def test_convert_tag(self):
-		rename_tag.convert_tag('search', 'not_search')
-		cb = partial(self.verify_tag_rename, 'search', 'not_search')
-		db.execute_cb(db.push_requests.select(), cb)
+    def test_convert_tag(self):
+        rename_tag.convert_tag('search', 'not_search')
+        cb = partial(self.verify_tag_rename, 'search', 'not_search')
+        db.execute_cb(db.push_requests.select(), cb)
 
-	def test_convert_notag(self):
-		rename_tag.convert_tag('nonexistent', 'random')
-		cb = partial(self.verify_database_state, self.request_data)
-		db.execute_cb(db.push_requests.select(), cb)
+    def test_convert_notag(self):
+        rename_tag.convert_tag('nonexistent', 'random')
+        cb = partial(self.verify_database_state, self.request_data)
+        db.execute_cb(db.push_requests.select(), cb)
 
 
 if __name__ == '__main__':
-	T.run()
+    T.run()

--- a/tests/test_rename_tag.py
+++ b/tests/test_rename_tag.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from functools import partial
+import os
+
+from mock import patch
+
+from core import db
+from core.db import DatabaseError
+from tools import rename_tag
+import testing as T
+
+
+class RenameTagTest(T.TestCase, T.FakeDataMixin):
+
+	@T.setup_teardown
+	def setup_db(self):
+		self.db_file_path = T.testdb.create_temp_db_file()
+		T.MockedSettings['db_uri'] = T.testdb.get_temp_db_uri(self.db_file_path)
+		with patch.dict(db.Settings, T.MockedSettings):
+			db.init_db()
+			self.insert_requests()
+			yield
+			db.finalize_db()
+			os.unlink(self.db_file_path)
+
+	def check_db_results(self, success, db_results):
+		if not success:
+			raise DatabaseError()
+
+	def verify_database_state(self, data, success, db_results):
+		self.check_db_results(success, db_results)
+
+		# id, user, state, repo, branch, *tags*, created, modified, etc...
+		data_tags = [d[5] for d in data]
+		#id, user, state, repo, branch, revision, *tags*, created, etc...
+		tags = [result[6] for result in db_results.fetchall()]
+
+		T.assert_sorted_equal(data_tags, tags)
+
+	def verify_tag_rename(self, oldtag, newtag, success, db_results):
+		self.check_db_results(success, db_results)
+
+		#id, user, state, repo, branch, revision, *tags*, created, etc...
+		tags = [result[6] for result in db_results.fetchall()]
+
+		T.assert_not_in(oldtag, tags)
+		T.assert_in(newtag, tags)
+
+	@patch('tools.rename_tag.convert_tag')
+	@patch('optparse.OptionParser.error')
+	@patch('optparse.OptionParser.parse_args', return_value=[None, []])
+	def test_main_noargs(self, parser, error, convert_tag):
+		rename_tag.main()
+		T.assert_equal(False, convert_tag.called)
+		error.assert_called_once_with('Incorrect number of arguments')
+
+	@patch('tools.rename_tag.convert_tag')
+	@patch('optparse.OptionParser.error')
+	@patch('optparse.OptionParser.parse_args',
+			return_value=[None, ['oldtag', 'newtag']])
+	def test_main_twoargs(self, parser, error, convert_tag):
+		parser.return_value=[None, ['oldtag', 'newtag']]
+		rename_tag.main()
+		convert_tag.assert_called_once_with('oldtag', 'newtag')
+		T.assert_equal(False, error.called)
+
+	def test_convert_tag(self):
+		rename_tag.convert_tag('search', 'not_search')
+		cb = partial(self.verify_tag_rename, 'search', 'not_search')
+		db.execute_cb(db.push_requests.select(), cb)
+
+	def test_convert_notag(self):
+		rename_tag.convert_tag('nonexistent', 'random')
+		cb = partial(self.verify_database_state, self.request_data)
+		db.execute_cb(db.push_requests.select(), cb)
+
+
+if __name__ == '__main__':
+	T.run()

--- a/tests/test_rename_tag.py
+++ b/tests/test_rename_tag.py
@@ -5,7 +5,6 @@ import os
 from mock import patch
 
 from core import db
-from core.db import DatabaseError
 from tools import rename_tag
 import testing as T
 
@@ -25,7 +24,7 @@ class RenameTagTest(T.TestCase, T.FakeDataMixin):
 
 	def check_db_results(self, success, db_results):
 		if not success:
-			raise DatabaseError()
+			raise db.DatabaseError()
 
 	def verify_database_state(self, data, success, db_results):
 		self.check_db_results(success, db_results)

--- a/tests/test_servlet_checklist.py
+++ b/tests/test_servlet_checklist.py
@@ -110,38 +110,6 @@ class ChecklistServletTest(T.TestCase, T.ServletTestMixin, T.FakeDataMixin):
             T.assert_in("for testuser1", response.body)
             T.assert_in("After Certifying - Do In Prod", response.body)
 
-    def test_checklist_plans_tag(self):
-        with fake_checklist_request():
-            # insert fake data from FakeDataMixin
-            fake_pushid = 2
-            self.insert_pushes()
-            self.insert_requests()
-            test1_request = self.get_requests_by_user('testuser1')[0]
-            self.insert_pushcontent(test1_request['id'], fake_pushid)
-
-            # insert fake checklist data
-            checklist_queries = [
-                db.push_checklist.insert({
-                    'request': test1_request['id'],
-                    'type': 'plans',
-                    'target': 'prod'
-                }),
-                db.push_checklist.insert({
-                    'request': test1_request['id'],
-                    'type': 'plans-cleanup',
-                    'target': 'post-verify-stage'
-                }),
-            ]
-            db.execute_transaction_cb(checklist_queries, on_db_return)
-
-            uri = "/checklist?id=%d" % fake_pushid
-            response = self.fetch(uri)
-            T.assert_equal(response.error, None)
-            T.assert_not_in("No checklist items for this push", response.body)
-            T.assert_not_in("multiple requests", response.body)
-            T.assert_in("for testuser1", response.body)
-            T.assert_in("After Certifying - Do In Stage", response.body)
-
     def test_checklist_pushplans_tag(self):
         with fake_checklist_request():
             # insert fake data from FakeDataMixin

--- a/tests/test_servlet_newrequest.py
+++ b/tests/test_servlet_newrequest.py
@@ -7,7 +7,7 @@ from core.util import get_servlet_urlspec
 from servlets.newrequest import NewRequestServlet
 import testing as T
 
-class NewRequestServletTest(T.TestCase, T.ServletTestMixin):
+class NewRequestServletTest(T.TestCase, T.ServletTestMixin, T.FakeDataMixin):
 
     def get_handlers(self):
         return [get_servlet_urlspec(NewRequestServlet)]
@@ -33,14 +33,13 @@ class NewRequestServletTest(T.TestCase, T.ServletTestMixin):
             num_results_before = len(results)
 
             request = {
-                'title': 'Test Push Request Title',
-                'user': 'testuser',
-                'tags': 'super-safe,logs',
-                'reviewid': 1,
-                'repo': 'testuser',
-                'branch': 'super_safe_fix',
-                'comments': 'No comment',
-                'description': 'I approve this fix!',
+                'request-title': 'Test Push Request Title',
+                'request-tags': 'super-safe,logs',
+                'request-review': 1,
+                'request-repo': 'testuser',
+                'request-branch': 'super_safe_fix',
+                'request-comments': 'No comment',
+                'request-description': 'I approve this fix!',
             }
 
             response = self.fetch(
@@ -55,3 +54,12 @@ class NewRequestServletTest(T.TestCase, T.ServletTestMixin):
             num_results_after = len(results)
 
             T.assert_equal(num_results_after, num_results_before + 1)
+
+            last_req = self.get_requests()[-1]
+            T.assert_equal(len(results), last_req['id'])
+            T.assert_equal('testuser', last_req['user'])
+            T.assert_equal(request['request-repo'], last_req['repo'])
+            T.assert_equal(request['request-branch'], last_req['branch'])
+            T.assert_equal(request['request-tags'], last_req['tags'])
+            T.assert_equal(request['request-comments'], last_req['comments'])
+            T.assert_equal(request['request-description'], last_req['description'])

--- a/tests/test_servlet_newrequest.py
+++ b/tests/test_servlet_newrequest.py
@@ -164,8 +164,8 @@ class NewRequestChecklistTest(T.TestCase, NewRequestChecklistMixin):
         tag = ['random_tag']
         self.assert_checklist_for_tags(tag)
 
-    def test_plans_with_cleanup(self):
-        tag = ['plans']
+    def test_pushplans_with_cleanup(self):
+        tag = ['pushplans']
         self.assert_checklist_for_tags(tag)
 
     def test_search_with_cleanup(self):
@@ -176,16 +176,16 @@ class NewRequestChecklistTest(T.TestCase, NewRequestChecklistMixin):
         tag = ['hoods']
         self.assert_checklist_for_tags(tag)
 
-    def test_plans_search_hoods_with_cleanup(self):
-        tags = ['plans', 'search-backend', 'hoods']
+    def test_pushplans_search_hoods_with_cleanup(self):
+        tags = ['pushplans', 'search-backend', 'hoods']
         self.assert_checklist_for_tags(tags)
 
 
 class EditRequestChecklistTest(T.TestCase, NewRequestChecklistMixin):
     """Verify corresponding checklists with existing requests"""
 
-    def test_plans_no_change(self):
-        tag = ['plans']
+    def test_pushplans_no_change(self):
+        tag = ['pushplans']
         orig_reqid = self.assert_checklist_for_tags(tag)
         new_reqid = self.assert_checklist_for_tags(tag, orig_reqid)
         T.assert_equal(orig_reqid, new_reqid)
@@ -202,11 +202,11 @@ class EditRequestChecklistTest(T.TestCase, NewRequestChecklistMixin):
         new_reqid = self.assert_checklist_for_tags(tag, orig_reqid)
         T.assert_equal(orig_reqid, new_reqid)
 
-    def test_plans_and_hoods(self):
+    def test_pushplans_and_hoods(self):
         tag = ['hoods']
         orig_reqid = self.assert_checklist_for_tags(tag)
 
-        tags = ['plans', 'hoods']
+        tags = ['pushplans', 'hoods']
         new_reqid = self.assert_checklist_for_tags(tags, orig_reqid)
 
         T.assert_equal(orig_reqid, new_reqid)
@@ -220,25 +220,25 @@ class EditRequestChecklistTest(T.TestCase, NewRequestChecklistMixin):
 
         T.assert_equal(orig_reqid, new_reqid)
 
-    def test_plans_and_search(self):
-        tag = ['plans']
+    def test_pushplans_and_search(self):
+        tag = ['pushplans']
         orig_reqid = self.assert_checklist_for_tags(tag)
 
-        tags = ['plans', 'search-backend']
+        tags = ['pushplans', 'search-backend']
         new_reqid = self.assert_checklist_for_tags(tags, orig_reqid)
 
         T.assert_equal(orig_reqid, new_reqid)
 
-    def test_plans_search_and_hoods(self):
-        tag = ['plans']
+    def test_pushplans_search_and_hoods(self):
+        tag = ['pushplans']
         orig_reqid = self.assert_checklist_for_tags(tag)
 
-        tags = ['plans', 'search-backend']
+        tags = ['pushplans', 'search-backend']
         new_reqid = self.assert_checklist_for_tags(tags, orig_reqid)
 
         T.assert_equal(orig_reqid, new_reqid)
 
-        tags = ['plans', 'search-backend', 'hoods']
+        tags = ['pushplans', 'search-backend', 'hoods']
         new_reqid = self.assert_checklist_for_tags(tags, orig_reqid)
 
         T.assert_equal(orig_reqid, new_reqid)

--- a/tools/rename_checklist_type.py
+++ b/tools/rename_checklist_type.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""
+Renames a checklist type for all checklists in the database.
+
+ A checklist type may have two forms - name and name-cleanup.
+
+With an appropriate config.yaml running from the root of the pushmanager-service:
+python -u tools/rename_checklist_type.py oldname newname
+
+Reverting the change (if tags are unique) is as simple as swapping the tags.
+
+Note:
+
+Checklist type renames will mostly require code changes.
+"""
+from functools import partial
+from optparse import OptionParser
+import sys
+
+import core.db as db
+
+
+def main():
+	usage = 'usage: %prog <oldtag> <newtag>'
+	parser = OptionParser(usage)
+	(_, args) = parser.parse_args()
+
+	if len(args) == 2:
+		db.init_db()
+		convert_checklist(args[0], args[1])
+		db.finalize_db()
+	else:
+		parser.error('Incorrect number of arguments')
+
+def convert_checklist(old, new):
+	print 'Renaming %s to %s in checklist types' % (old, new)
+
+	cb = partial(convert_checklist_callback, old, new)
+
+	cselect_query = db.push_checklist.select()
+	db.execute_transaction_cb([cselect_query], cb)
+
+
+def convert_checklist_callback(old, new, success, db_results):
+	check_db_results(success, db_results)
+
+	checklists = db_results[0].fetchall()
+
+	convert = {
+		old: new,
+		'%s-cleanup' % old: '%s-cleanup' % new
+	}
+	
+	update_queries = []
+	for checklist in checklists:
+		if checklist['type'] in convert.keys():
+			update_query = db.push_checklist.update().where(
+				db.push_checklist.c.id == checklist.id
+				).values({'type': convert[checklist['type']]})
+			update_queries.append(update_query)
+
+	db.execute_transaction_cb(update_queries, check_db_results)
+
+def check_db_results(success, db_results):
+	if not success:
+		raise db.DatabaseError()
+
+
+if __name__ == '__main__':
+	sys.exit(main())

--- a/tools/rename_tag.py
+++ b/tools/rename_tag.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+Renames a tag for all push requests in the database.
+
+With an appropriate config.yaml running from the root of the pushmanager-service:
+python -u tools/rename_tag.py oldtag newtag
+
+Reverting the change (if tags are unique) is as simple as swapping the tags.
+
+Note:
+
+Some tag renames may need to be accompanied with a checklist_type rename as
+well. Tags handled specially in the pushmanager will also need corresponding
+code changes.
+"""
+from functools import partial
+from optparse import OptionParser
+import sys
+
+import core.db as db
+from core.util import add_to_tags_str
+from core.util import del_from_tags_str
+from core.util import tags_contain
+from servlets.checklist import checklist_reminders
+
+def main():
+	usage = 'usage: %prog <oldtype> <newtype>'
+	parser = OptionParser(usage)
+	(_, args) = parser.parse_args()
+
+	if len(args) == 2:
+		db.init_db()
+		convert_tag(args[0], args[1])
+		db.finalize_db()
+	else:
+		parser.error('Incorrect number of arguments')
+
+
+def convert_tag(old, new):
+	print 'Renaming %s to %s in tags' % (old, new)
+
+	cb = partial(convert_tag_callback, old, new)
+
+	rselect_query = db.push_requests.select()
+	db.execute_transaction_cb([rselect_query], cb)
+
+	if old in checklist_reminders.keys():
+		print """%s is handled specially in pushmanager.
+Additional code changes are required before pushmanger can be restarted.
+""" % old
+
+
+def convert_tag_callback(oldtag, newtag, success, db_results):
+	check_db_results(success, db_results)
+
+	requests = db_results[0].fetchall()
+
+	update_queries = []
+	for request in requests:
+		if tags_contain(request['tags'], [oldtag]):
+			updated_tags = del_from_tags_str(request['tags'], oldtag)
+			updated_tags = add_to_tags_str(updated_tags, newtag)
+			update_query = db.push_requests.update().where(
+				db.push_requests.c.id == request.id
+				).values({'tags': updated_tags})
+			update_queries.append(update_query)
+
+	db.execute_transaction_cb(update_queries, check_db_results)
+
+
+def check_db_results(success, db_results):
+	if not success:
+		raise db.DatabaseError()
+
+
+def help():
+	print "%s <oldtag> <newtag>" % sys.argv[0]
+
+
+if __name__ == '__main__':
+	sys.exit(main())

--- a/tools/rename_tag.py
+++ b/tools/rename_tag.py
@@ -73,9 +73,5 @@ def check_db_results(success, db_results):
 		raise db.DatabaseError()
 
 
-def help():
-	print "%s <oldtag> <newtag>" % sys.argv[0]
-
-
 if __name__ == '__main__':
 	sys.exit(main())

--- a/tools/rename_tag.py
+++ b/tools/rename_tag.py
@@ -24,54 +24,54 @@ from core.util import tags_contain
 from servlets.checklist import checklist_reminders
 
 def main():
-	usage = 'usage: %prog <oldtype> <newtype>'
-	parser = OptionParser(usage)
-	(_, args) = parser.parse_args()
+    usage = 'usage: %prog <oldtype> <newtype>'
+    parser = OptionParser(usage)
+    (_, args) = parser.parse_args()
 
-	if len(args) == 2:
-		db.init_db()
-		convert_tag(args[0], args[1])
-		db.finalize_db()
-	else:
-		parser.error('Incorrect number of arguments')
+    if len(args) == 2:
+        db.init_db()
+        convert_tag(args[0], args[1])
+        db.finalize_db()
+    else:
+        parser.error('Incorrect number of arguments')
 
 
 def convert_tag(old, new):
-	print 'Renaming %s to %s in tags' % (old, new)
+    print 'Renaming %s to %s in tags' % (old, new)
 
-	cb = partial(convert_tag_callback, old, new)
+    cb = partial(convert_tag_callback, old, new)
 
-	rselect_query = db.push_requests.select()
-	db.execute_transaction_cb([rselect_query], cb)
+    rselect_query = db.push_requests.select()
+    db.execute_transaction_cb([rselect_query], cb)
 
-	if old in checklist_reminders.keys():
-		print """%s is handled specially in pushmanager.
+    if old in checklist_reminders.keys():
+        print """%s is handled specially in pushmanager.
 Additional code changes are required before pushmanger can be restarted.
 """ % old
 
 
 def convert_tag_callback(oldtag, newtag, success, db_results):
-	check_db_results(success, db_results)
+    check_db_results(success, db_results)
 
-	requests = db_results[0].fetchall()
+    requests = db_results[0].fetchall()
 
-	update_queries = []
-	for request in requests:
-		if tags_contain(request['tags'], [oldtag]):
-			updated_tags = del_from_tags_str(request['tags'], oldtag)
-			updated_tags = add_to_tags_str(updated_tags, newtag)
-			update_query = db.push_requests.update().where(
-				db.push_requests.c.id == request.id
-				).values({'tags': updated_tags})
-			update_queries.append(update_query)
+    update_queries = []
+    for request in requests:
+        if tags_contain(request['tags'], [oldtag]):
+            updated_tags = del_from_tags_str(request['tags'], oldtag)
+            updated_tags = add_to_tags_str(updated_tags, newtag)
+            update_query = db.push_requests.update().where(
+                db.push_requests.c.id == request.id
+                ).values({'tags': updated_tags})
+            update_queries.append(update_query)
 
-	db.execute_transaction_cb(update_queries, check_db_results)
+    db.execute_transaction_cb(update_queries, check_db_results)
 
 
 def check_db_results(success, db_results):
-	if not success:
-		raise db.DatabaseError()
+    if not success:
+        raise db.DatabaseError()
 
 
 if __name__ == '__main__':
-	sys.exit(main())
+    sys.exit(main())

--- a/ui_modules.py
+++ b/ui_modules.py
@@ -68,13 +68,6 @@ class Request(UIModule):
         if 'buildbot' in tags:
             tags['buildbot'] = "http://%s/rev/%s" % (Settings['buildbot']['servername'], request['revision'])
 
-        if 'plans' in tags:
-            tags['plans'] = "https://%s/?p=%s.git;a=history;f=pushplans;hb=refs/heads/%s" % (
-                Settings['git']['gitweb_servername'],
-                repo,
-                request['branch']
-            )
-
         if 'pushplans' in tags:
             tags['pushplans'] = "https://%s/?p=%s.git;a=history;f=pushplans;hb=refs/heads/%s" % (
                 Settings['git']['gitweb_servername'],

--- a/ui_modules.py
+++ b/ui_modules.py
@@ -75,6 +75,13 @@ class Request(UIModule):
                 request['branch']
             )
 
+        if 'pushplans' in tags:
+            tags['pushplans'] = "https://%s/?p=%s.git;a=history;f=pushplans;hb=refs/heads/%s" % (
+                Settings['git']['gitweb_servername'],
+                repo,
+                request['branch']
+            )
+
         return sorted(tags.iteritems())
 
 class NewRequestDialog(UIModule):


### PR DESCRIPTION
This branch can be combined with issue #10 either on top of #10 or in lieue of #10.

This branch completely replaces the plans tag with pushplans and is not backwards-compatible (unknown tags will result in KeyErrors in various places). A script is provided in pushplans in the last commit that may be used to rename plans/plans-cleanup to pushplans/pushplans-cleanup in the database.
