### PR TITLE
Fixes a logging issue that can potentially expose auth credentials

### DIFF
--- a/core/git.py
+++ b/core/git.py
@@ -78,7 +78,6 @@ class GitQueue(object):
             'title': req['title'],
             'repo': req['repo'],
             'branch': req['branch'],
-            'repository': repository,
             'stderr': stderr,
         }
         if rc:
@@ -92,7 +91,7 @@ class GitQueue(object):
                     <em>%(repo)s/%(branch)s</em>
                 </p>
                 <p>
-                    Attempting to query the specified repository (%(repository)s) failed with
+                    Attempting to query the specified repository failed with
                     the following error(s):
                 </p>
                 <pre>
@@ -105,7 +104,6 @@ class GitQueue(object):
                 """)
             msg %= EscapedDict(query_details)
             subject = '[push error] %s - %s' % (req['user'], req['title'])
-            #MailQueue.enqueue_user_email([request_info['user']], msg, subject)
             MailQueue.enqueue_user_email([user_to_notify], msg, subject)
             return None
 

--- a/core/git.py
+++ b/core/git.py
@@ -124,7 +124,7 @@ class GitQueue(object):
                     <em>%(repo)s/%(branch)s</em>
                 </p>
                 <p>
-                    The specified branch (%(branch)s) was not found in the repository (%(repository)s).
+                    The specified branch (%(branch)s) was not found in the repository.
                 </p>
                 <p>
                     Regards,<br/>


### PR DESCRIPTION
Removes `(%(repository)s)` from two log messages, because the full URI can potentially contain sensitive information.

While this doesn't prevent accidental disclosure using insecure protocols (for example, basic auth over unencrypted HTTP), this prevents all credentials in the `auth` and other URI fields from being sent over email, which would have potentially disclosed full connection details for the repository in the process.
