### PR TITLE
Restrict verify to pushmaster and user

### DIFF
--- a/templates/modules/request.html
+++ b/templates/modules/request.html
@@ -22,7 +22,9 @@
 	<button class="pushmaster-delay-request">Delay</button>
 	{% end %}
 
+	{% if pushmaster or request['user'] == current_user %}
 	<button class="verify-request">Verify</button>
+	{% end %}
 	<button class="pickme-request">Pick me!</button>
 	<button class="unpickme-request">Don't pick me!</button>
 </span>

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import testify
 
@@ -8,6 +9,7 @@ from testify.__init__ import *
 from mocksettings import MockedSettings
 from testservlet import AsyncTestCase
 from testservlet import ServletTestMixin
+from testservlet import TemplateTestCase
 from testdb import *
 
 
@@ -15,5 +17,6 @@ __all__ = [
     AsyncTestCase,
     MockedSettings,
     testify,
-    ServletTestMixin
+    ServletTestMixin,
+    TemplateTestCase
 ]

--- a/testing/testservlet.py
+++ b/testing/testservlet.py
@@ -1,11 +1,15 @@
+# -*- coding: utf-8 -*-
 import logging
 import os
 
 import mock
 import tornado.web
+from lxml import etree
 from tornado.testing import AsyncHTTPTestCase
 
 from core import db
+from core.requesthandler import RequestHandler
+from testify.utils import turtle
 import ui_modules
 import testing as T
 
@@ -35,6 +39,31 @@ class AsyncTestCase(AsyncHTTPTestCase):
             autoescape = None,
         )
         return app
+
+
+class TemplateTestCase(T.TestCase):
+    """Bare minimum setup to render and test templates"""
+    __test__ = False
+
+    authenticated = False
+
+    @T.setup
+    def setup_servlet(self):
+        application = turtle.Turtle()
+        application.settings = {
+            'static_path': os.path.join(os.path.dirname(__file__), "../static"),
+            'template_path': os.path.join(os.path.dirname(__file__), "../templates"),
+        }
+        if self.authenticated:
+            application.settings['cookie_secret'] = 'cookie_secret'
+        request = turtle.Turtle()
+        self.servlet = RequestHandler(application, request)
+
+    def render_etree(self, page, *args, **kwargs):
+        self.servlet.render(page, *args, **kwargs)
+        rendered_page = ''.join(self.servlet._write_buffer)
+        tree = etree.HTML(rendered_page)
+        return tree
 
 
 class ServletTestMixin(AsyncTestCase):

--- a/tests/test_servlet_newrequest.py
+++ b/tests/test_servlet_newrequest.py
@@ -7,7 +7,7 @@ from core.util import get_servlet_urlspec
 from servlets.newrequest import NewRequestServlet
 import testing as T
 
-class NewRequestServletTest(T.TestCase, T.ServletTestMixin):
+class NewRequestServletTest(T.TestCase, T.ServletTestMixin, T.FakeDataMixin):
 
     def get_handlers(self):
         return [get_servlet_urlspec(NewRequestServlet)]
@@ -33,14 +33,13 @@ class NewRequestServletTest(T.TestCase, T.ServletTestMixin):
             num_results_before = len(results)
 
             request = {
-                'title': 'Test Push Request Title',
-                'user': 'testuser',
-                'tags': 'super-safe,logs',
-                'reviewid': 1,
-                'repo': 'testuser',
-                'branch': 'super_safe_fix',
-                'comments': 'No comment',
-                'description': 'I approve this fix!',
+                'request-title': 'Test Push Request Title',
+                'request-tags': 'super-safe,logs',
+                'request-review': 1,
+                'request-repo': 'testuser',
+                'request-branch': 'super_safe_fix',
+                'request-comments': 'No comment',
+                'request-description': 'I approve this fix!',
             }
 
             response = self.fetch(
@@ -55,3 +54,12 @@ class NewRequestServletTest(T.TestCase, T.ServletTestMixin):
             num_results_after = len(results)
 
             T.assert_equal(num_results_after, num_results_before + 1)
+
+            last_req = self.get_requests()[-1]
+            T.assert_equal(len(results), last_req['id'])
+            T.assert_equal('testuser', last_req['user'])
+            T.assert_equal(request['request-repo'], last_req['repo'])
+            T.assert_equal(request['request-branch'], last_req['branch'])
+            T.assert_equal(request['request-tags'], last_req['tags'])
+            T.assert_equal(request['request-comments'], last_req['comments'])
+            T.assert_equal(request['request-description'], last_req['description'])

--- a/tests/test_template_request.py
+++ b/tests/test_template_request.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+import testing as T
+
+class RequestTemplateTest(T.TemplateTestCase):
+
+    authenticated = True
+    request_page = 'modules/request.html'
+
+    def render_module_request_with_users(self, request_user, current_user, pushmaster=False):
+        """Provide enough information to render modules/request"""
+        request = {
+            'id': 0,
+            'repo': 'non-existent',
+            'branch': 'non-existent',
+            'user': request_user,
+            'reviewid': 0,
+            'title': 'some title',
+            'revision': '0' * 40,
+            'state': 'requested',
+            'created': 'nodate',
+            'modified': 'nodate',
+            'description': 'nondescript',
+            'comments': 'nocomment',
+        }
+
+        web_hooks = {
+            'service_name': 'noname',
+            'get_request_url': 'non://existent',
+        }
+
+        return self.render_etree(self.request_page,
+            pushmaster=pushmaster,
+            current_user=current_user,
+            request=request,
+            web_hooks=web_hooks,
+            cherry_string='',
+            expand=False,
+            push_buttons=True,
+            edit_buttons=False,
+            show_ago=False,
+            tags=None,
+            show_state_inline=False,
+            review=None,
+            repo_url='non://existent',
+            branch_url='non://existent',
+            create_time='nodate',
+        )
+
+    def assert_button_link(self, button, tree, num=1):
+        classname = '%s-request' % button.lower()
+        text = button.capitalize()
+
+        buttons = []
+        for button in tree.iter('button'):
+            if button.attrib['class'] == classname:
+                T.assert_equal(text, button.text)
+                buttons.append(button)
+        T.assert_equal(num, len(buttons))
+
+    def test_module_request_verify_random_user(self):
+        tree = self.render_module_request_with_users(
+                'testuser', 'notme', False)
+        self.assert_button_link('verify', tree, 0)
+
+    def test_module_request_verify_pushmaster(self):
+        tree = self.render_module_request_with_users(
+                'testuser', 'notme', True)
+        self.assert_button_link('verify', tree, 1)
+
+    def test_module_request_verify_requester(self):
+        tree = self.render_module_request_with_users(
+                'testuser', 'testuser', False)
+        self.assert_button_link('verify', tree, 1)
+
+
+if __name__ == '__main__':
+    T.run()


### PR DESCRIPTION
Verify should only be available to those in the know - namely the user who created the pull request and the pushmaster.

No known existing tests for templates yet. Verified in test instance by playing around with the database and changing users for the pushmaster and the request owner.
