### PR TITLE
Remove search-backend from Quick Tags

### DIFF
--- a/templates/modules/newrequest.html
+++ b/templates/modules/newrequest.html
@@ -20,7 +20,6 @@
 		<span class="tag-suggestion" title="This push request involves push plans.">plans</span>
 		<span class="tag-suggestion" title="This push request needs special handling - the pushmaster should talk to the requestor before pushing it.">special</span>
 		<span class="tag-suggestion" title="This push request is urgent (p0).">urgent</span>
-		<span class="tag-suggestion" title="This push request involves changes to the search backend and should be coordinated with a member of the Search team.">search-backend</span>
 		<span class="tag-suggestion" title="This push request involves updating translations.">l10n</span>
 		<span class="tag-suggestion" title="This push request is just for updating translations.">l10n-only</span>
 		<span class="tag-suggestion" title="This push request is just for pushing YelpHoods data.">hoods</span>

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -8,6 +8,7 @@ from testify.__init__ import *
 from mocksettings import MockedSettings
 from testservlet import AsyncTestCase
 from testservlet import ServletTestMixin
+from testservlet import TemplateTestCase
 from testdb import *
 
 
@@ -15,5 +16,6 @@ __all__ = [
     AsyncTestCase,
     MockedSettings,
     testify,
-    ServletTestMixin
+    ServletTestMixin,
+    TemplateTestCase
 ]

--- a/testing/testservlet.py
+++ b/testing/testservlet.py
@@ -3,9 +3,12 @@ import os
 
 import mock
 import tornado.web
+from lxml import etree
 from tornado.testing import AsyncHTTPTestCase
 
 from core import db
+from core.requesthandler import RequestHandler
+from testify.utils import turtle
 import ui_modules
 import testing as T
 
@@ -35,6 +38,31 @@ class AsyncTestCase(AsyncHTTPTestCase):
             autoescape = None,
         )
         return app
+
+
+class TemplateTestCase(T.TestCase):
+    """Bare minimum setup to render and test templates"""
+    __test__ = False
+
+    authenticated = False
+
+    @T.setup
+    def setup_servlet(self):
+        application = turtle.Turtle()
+        application.settings = {
+            'static_path': os.path.join(os.path.dirname(__file__), "../static"),
+            'template_path': os.path.join(os.path.dirname(__file__), "../templates"),
+        }
+        if self.authenticated:
+            application.settings['cookie_secret'] = 'cookie_secret'
+        request = turtle.Turtle()
+        self.servlet = RequestHandler(application, request)
+
+    def render_etree(self, page, *args, **kwargs):
+        self.servlet.render(page, *args, **kwargs)
+        rendered_page = ''.join(self.servlet._write_buffer)
+        tree = etree.HTML(rendered_page)
+        return tree
 
 
 class ServletTestMixin(AsyncTestCase):

--- a/tests/test_servlet_newrequest.py
+++ b/tests/test_servlet_newrequest.py
@@ -63,3 +63,7 @@ class NewRequestServletTest(T.TestCase, T.ServletTestMixin, T.FakeDataMixin):
             T.assert_equal(request['request-tags'], last_req['tags'])
             T.assert_equal(request['request-comments'], last_req['comments'])
             T.assert_equal(request['request-description'], last_req['description'])
+
+
+if __name__ == '__main__':
+	T.run()

--- a/tests/test_template_newrequest.py
+++ b/tests/test_template_newrequest.py
@@ -1,0 +1,24 @@
+# -*- code:utf8 -*-
+import testing as T
+
+class NewRequestTemplateTest(T.TemplateTestCase):
+
+    authenticated = True
+    newrequest_page = 'modules/newrequest.html'
+
+    tags = ['feature', 'fix' ,'cleanup', 'buildbot', 'caches', 'plans',
+        'special', 'urgent', 'l10n', 'l10n-only', 'hoods']
+
+    def test_request_quicktags(self):
+        tree = self.render_etree(self.newrequest_page)
+
+        found_tags = []
+        for span in tree.iter('span'):
+            if span.attrib['class'] == 'tag-suggestion':
+                found_tags.append(span.text)
+
+        T.assert_sorted_equal(self.tags, found_tags)
+
+
+if __name__ == '__main__':
+    T.run()

--- a/tests/test_template_newrequest.py
+++ b/tests/test_template_newrequest.py
@@ -6,7 +6,7 @@ class NewRequestTemplateTest(T.TemplateTestCase):
     authenticated = True
     newrequest_page = 'modules/newrequest.html'
 
-    tags = ['feature', 'fix' ,'cleanup', 'buildbot', 'caches', 'plans',
+    tags = ['feature', 'fix' ,'cleanup', 'buildbot', 'caches', 'pushplans',
         'special', 'urgent', 'l10n', 'l10n-only', 'hoods']
 
     def test_request_quicktags(self):


### PR DESCRIPTION
search-backend is no longer needed as a tag
Not removing all other references so as to preserve historical data
