### PR TITLE
Add watchers

### DIFF
--- a/UPDATING
+++ b/UPDATING
@@ -1,8 +1,8 @@
 2013.07.29
-  AFFECTS: Users with existing installs before commit 93CFFB559
+  AFFECTS: Users with existing installs before commit $add_watchers-merge$
   AUTHOR: milki
 
-  As of commit 93CFFB559, a new column 'watchers' has been added to the
+  As of commit $add_watchers-merge$, a new column 'watchers' has been added to the
   'pull_requests' table. Existing installs will 500 error until the
   database has been updated.
 

--- a/UPDATING
+++ b/UPDATING
@@ -1,3 +1,14 @@
+2013.07.29
+  AFFECTS: Users with existing installs before commit 93CFFB559
+  AUTHOR: milki
+
+  As of commit 93CFFB559, a new column 'watchers' has been added to the
+  'pull_requests' table. Existing installs will 500 error until the
+  database has been updated.
+
+  A convenience script, 'pushplans/add_watchers.sql' has been included
+  to facilitate the database update.
+
 2013.06.18:
   AFFECTS: Users with existing installs before commit 7A89C5A7F
   AUTHOR: milki

--- a/core/db.py
+++ b/core/db.py
@@ -89,6 +89,7 @@ class PushRequests(Base):
     comments = Column(String)
     reviewid = Column(Integer, nullable=True)
     description = Column(String)
+    watchers = Column(String, nullable=True)
 
 
 push_checklist = PushCheckList.__table__

--- a/core/util.py
+++ b/core/util.py
@@ -148,6 +148,7 @@ def request_to_jsonable(request):
         (k, request[k]) for k in (
             'id',
             'user',
+            'watchers',
             'state',
             'repo',
             'branch',

--- a/pushmanager_main.py
+++ b/pushmanager_main.py
@@ -47,6 +47,7 @@ from servlets.userlist import UserListServlet
 from servlets.verifyrequest import VerifyRequestServlet
 
 import ui_modules
+import ui_methods
 
 class NullRequestHandler(RequestHandler):
     def get(self): pass
@@ -169,6 +170,7 @@ class PushManagerApp(Application):
             login_url = "/login",
             cookie_secret = Settings['cookie_secret'],
             ui_modules = ui_modules,
+            ui_methods = ui_methods,
             autoescape = None,
         )
 

--- a/pushplans/add_watchers.sql
+++ b/pushplans/add_watchers.sql
@@ -1,0 +1,22 @@
+/*
+Add watchers column to push_requests.
+*/
+
+# MySQL Syntax
+ALTER TABLE `push_requests`
+  ADD COLUMN `watchers` text default NULL AFTER `description`;
+
+/* ROLLBACK COMMANDS
+
+ALTER TABLE `push_requests`
+  DROP COLUMN `watchers`;
+
+*/
+
+# Sqlite3 Syntax
+# WARNING: BACKUP DATABASE FIRST!
+# sqlite3 has no rollback equivalent for add column
+/*
+ALTER TABLE 'push_requests'
+  ADD COLUMN 'watchers' VARCHAR;
+*/

--- a/servlets/blesspush.py
+++ b/servlets/blesspush.py
@@ -40,10 +40,16 @@ class BlessPushServlet(RequestHandler):
 
         _, blessed_requests, push_results = db_results
         for req in blessed_requests:
+            if req['watchers']:
+                user_string = '%s (%s)' % (req['user'], req['watchers'])
+                users = [req['user']] + req['watchers'].split(',')
+            else:
+                user_string = req['user']
+                users = [req['user']]
             msg = (
                 """
                 <p>
-                    %(pushmaster)s has deployed your request to production:
+                    %(pushmaster)s has deployed request for %(user)s to production:
                 </p>
                 <p>
                     <strong>%(user)s - %(title)s</strong><br />
@@ -55,18 +61,19 @@ class BlessPushServlet(RequestHandler):
                 </p>"""
                 ) % core.util.EscapedDict({
                     'pushmaster': self.current_user,
-                    'user': req['user'],
+                    'user': user_string,
                     'title': req['title'],
                     'repo': req['repo'],
                     'branch': req['branch'],
                 })
-            subject = "[push] %s - %s" % (req['user'], req['title'])
-            MailQueue.enqueue_user_email([req['user']], msg, subject)
-            msg = '%(pushmaster)s has deployed your request "%(title)s" to production.' % {
+            subject = "[push] %s - %s" % (user_string, req['title'])
+            MailQueue.enqueue_user_email(users, msg, subject)
+            msg = '%(pushmaster)s has deployed request "%(title)s" for %(user)s to production.' % {
                     'pushmaster': self.current_user,
                     'title': req['title'],
+                    'user': user_string,
                 }
-            XMPPQueue.enqueue_user_xmpp([req['user']], msg)
+            XMPPQueue.enqueue_user_xmpp(users, msg)
 
         push = push_results.fetchone()
         if push['extra_pings']:

--- a/servlets/discardrequest.py
+++ b/servlets/discardrequest.py
@@ -34,10 +34,16 @@ class DiscardRequestServlet(RequestHandler):
             # We didn't actually discard the record, for whatever reason
             return self.redirect("/requests?user=%s" % self.current_user)
 
+        if req['watchers']:
+            user_string = '%s (%s)' % (req['user'], req['watchers'])
+            users = [req['user']] + req['watchers'].split(',')
+        else:
+            user_string = req['user']
+            users = [req['user']]
         msg = (
             """
             <p>
-                Your request has been discarded:
+                Request for %(user)s has been discarded:
             </p>
             <p>
                 <strong>%(user)s - %(title)s</strong><br />
@@ -49,13 +55,13 @@ class DiscardRequestServlet(RequestHandler):
             </p>"""
             ) % core.util.EscapedDict({
                 'pushmaster': self.current_user,
-                'user': req['user'],
+                'user': user_string,
                 'title': req['title'],
                 'repo': req['repo'],
                 'branch': req['branch'],
             })
-        subject = "[push] %s - %s" % (req['user'], req['title'])
-        MailQueue.enqueue_user_email([req['user']], msg, subject)
+        subject = "[push] %s - %s" % (user_string, req['title'])
+        MailQueue.enqueue_user_email(users, msg, subject)
 
         self.redirect("/requests?user=%s" % self.current_user)
 

--- a/servlets/livepush.py
+++ b/servlets/livepush.py
@@ -63,10 +63,17 @@ class LivePushServlet(RequestHandler):
                 review_id = int(req['reviewid'])
                 RBQueue.enqueue_review(review_id)
 
+            if req['watchers']:
+                user_string = '%s (%s)' % (req['user'], req['watchers'])
+                users = [req['user']] + req['watchers'].split(',')
+            else:
+                user_string = req['user']
+                users = [req['user']]
+
             msg = (
                 """
                 <p>
-                    %(pushmaster)s has certified your request as stable in production:
+                    %(pushmaster)s has certified request for %(user)s as stable in production:
                 </p>
                 <p>
                     <strong>%(user)s - %(title)s</strong><br />
@@ -78,12 +85,10 @@ class LivePushServlet(RequestHandler):
                 </p>"""
                 ) % core.util.EscapedDict({
                     'pushmaster': self.current_user,
-                    'user': req['user'],
+                    'user': user_string,
                     'title': req['title'],
                     'repo': req['repo'],
                     'branch': req['branch'],
                 })
-            subject = "[push] %s - %s" % (req['user'], req['title'])
-            MailQueue.enqueue_user_email([req['user']], msg, subject)
-
-
+            subject = "[push] %s - %s" % (user_string, req['title'])
+            MailQueue.enqueue_user_email(users, msg, subject)

--- a/servlets/newpush.py
+++ b/servlets/newpush.py
@@ -64,12 +64,18 @@ class NewPushServlet(RequestHandler):
 
         insert_results, select_results = db_results
         pushurl = '/push?id=%s' % insert_results.lastrowid
+
+        def users_involved(request):
+            if request['watchers']:
+                return [request['user']] + request['watchers'].split(',')
+            return [request['user']]
+
         if self.pushtype in ('private', 'morning'):
             people = None
         elif self.pushtype == 'urgent':
-            people = set(x['user'] for x in select_results if 'urgent' in x['tags'].split(','))
+            people = set(user for x in select_results for user in users_involved(x) if 'urgent' in x['tags'].split(','))
         else:
-            people = set(x['user'] for x in select_results)
+            people = set(user for x in select_results for user in users_involved(x))
 
         send_notifications(people, self.pushtype, pushurl)
 

--- a/servlets/newrequest.py
+++ b/servlets/newrequest.py
@@ -28,6 +28,8 @@ class NewRequestServlet(RequestHandler):
             except (ValueError, TypeError):
                 return self.send_error(500)
 
+        watchers = ','.join(map(str.strip, self._arg('request-watchers').split(',')))
+
         if self.requestid != '':
             self.requestid = int(self.requestid)
             query = db.push_requests.update().where(
@@ -41,6 +43,7 @@ class NewRequestServlet(RequestHandler):
                     'branch': self._arg('request-branch'),
                     'comments': self._arg('request-comments'),
                     'description': self._arg('request-description'),
+                    'watchers': watchers,
                     'modified': time.time(),
                     'revision': '0'*40,
                 })
@@ -54,6 +57,7 @@ class NewRequestServlet(RequestHandler):
                 'branch': self._arg('request-branch'),
                 'comments': self._arg('request-comments'),
                 'description': self._arg('request-description'),
+                'watchers': watchers,
                 'created': time.time(),
                 'modified': time.time(),
                 'state': 'requested',

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -585,6 +585,7 @@ ul.user-list li li {
 #pickme-items .add-request,
 #pickme-items .pushmaster-delay-request,
 #pickme-items .mine .unpickme-request,
+#pickme-items .pushmaster .unpickme-request,
 #added-items .remove-request,
 #staged-items .remove-request,
 #staged-items .verify-request,

--- a/static/js/modules/newrequest.js
+++ b/static/js/modules/newrequest.js
@@ -34,7 +34,7 @@ $(function() {
     };
     $('#request-info-form').submit(PushManager.NewRequestDialog.validate);
 
-    PushManager.NewRequestDialog.open_new_request = function(title, branch, repo, review, comments, description, tags, requestid, notyours) {
+    PushManager.NewRequestDialog.open_new_request = function(title, branch, repo, review, comments, description, watchers, tags, requestid, notyours) {
         var d = PushManager.NewRequestDialog.element;
 
         d.find('#request-form-title').val(title || '');
@@ -44,6 +44,7 @@ $(function() {
         d.find('#request-form-tags').val(tags || '');
         d.find('#request-form-comments').val(comments || '');
         d.find('#request-form-description').val(description || '');
+        d.find('#request-form-watchers').val(watchers || '');
         d.find('#request-form-id').val(requestid || '');
         d.find('#request-not-yours-notice').toggle(notyours || false);
 
@@ -68,6 +69,7 @@ $(function() {
             that.attr('reviewid'),
             that.find('.request-comments').text().replace(/\n{3,}/g, '\n\n'),
             that.find('.request-description').text(),
+            that.attr('watchers'),
             tags,
             that.attr('request'),
             that.attr('user') != PushManager.current_user

--- a/static/js/push.js
+++ b/static/js/push.js
@@ -89,11 +89,11 @@ $(function() {
         var contents = $(this).siblings('.item-count').text();
 
         var people_pat = new RegExp(    // person, person (person, person), person (person), person
-            "(?:[a-z]+" +                   // A username, possibly followed by:
+            "(?:[a-z]+" +                   // A username, possibly followed by
                 "(?:\\s\\(" +               //   a space and (
-                    "(?:[a-z]+,?\\s?)+" +   //   and or more comma seperated usernames
+                    "(?:[a-z]+,?\\s?)+" +   //   and one or more usernames (possibly separated by comma and/or a single space)
                 "\\))?" +                   //   followed by a )
-            ",?\\s?" +                      // possibibly followed by a command and space
+            ",?\\s?" +                      // possibly followed by a command and space
             ")+")                           // and more of the same
 
         var people = (people_pat.exec(contents) || [""])[0];

--- a/static/js/push.js
+++ b/static/js/push.js
@@ -87,7 +87,16 @@ $(function() {
     });
     $('.message-people').live('click', function() {
         var contents = $(this).siblings('.item-count').text();
-        var people = (/(?:[a-z]+(?:\s\((?:[a-z]+,?\s?)+\))?,?\s?)+/.exec(contents) || [""])[0];
+
+        var people_pat = new RegExp(    // person, person (person, person), person (person), person
+            "(?:[a-z]+" +                   // A username, possibly followed by:
+                "(?:\\s\\(" +               //   a space and (
+                    "(?:[a-z]+,?\\s?)+" +   //   and or more comma seperated usernames
+                "\\))?" +                   //   followed by a )
+            ",?\\s?" +                      // possibibly followed by a command and space
+            ")+")                           // and more of the same
+
+        var people = (people_pat.exec(contents) || [""])[0];
         PushManager.send_message_dialog(people);
     });
     $('#message-all').live('click', function() {

--- a/static/js/push.js
+++ b/static/js/push.js
@@ -87,7 +87,7 @@ $(function() {
     });
     $('.message-people').live('click', function() {
         var contents = $(this).siblings('.item-count').text();
-        var people = (/(?:[a-z]+,?\s?)+/.exec(contents) || [""])[0];
+        var people = (/(?:[a-z]+(?:\s\((?:[a-z]+,?\s?)+\))?,?\s?)+/.exec(contents) || [""])[0];
         PushManager.send_message_dialog(people);
     });
     $('#message-all').live('click', function() {
@@ -255,7 +255,11 @@ $(function() {
     PushManager.requests_to_names = function(requests) {
         var hash = new Object();
         requests.each(function() {
-            hash[$(this).attr('user')] = true;
+            if($(this).attr('watchers')) {
+                hash[$(this).attr('user') + ' (' + $(this).attr('watchers') + ')'] = true;
+            } else {
+                hash[$(this).attr('user')] = true;
+            }
         });
         var names = new Array();
         for(value in hash) {

--- a/templates/modules/newrequest.html
+++ b/templates/modules/newrequest.html
@@ -43,6 +43,9 @@
 	<label for="request-form-comments">Comments</label>
 	<textarea name="request-comments" id="request-form-comments"></textarea>
 
+	<label for="request-form-watchers">Additional Watchers</label>
+	<input name="request-watchers" id="request-form-watchers" />
+
 	<input type="hidden" name="request-id" id="request-form-id" value="" />
 
 	<p id="request-not-yours-notice">Updating this request will transfer its ownership to you.</p>

--- a/templates/modules/newrequest.html
+++ b/templates/modules/newrequest.html
@@ -42,7 +42,7 @@
 	<label for="request-form-comments">Comments</label>
 	<textarea name="request-comments" id="request-form-comments"></textarea>
 
-	<label for="request-form-watchers">Additional Watchers</label>
+	<label for="request-form-watchers">Additional Watchers (comma separated)</label>
 	<input name="request-watchers" id="request-form-watchers" />
 
 	<input type="hidden" name="request-id" id="request-form-id" value="" />

--- a/templates/modules/request-buttons.html
+++ b/templates/modules/request-buttons.html
@@ -9,7 +9,7 @@
 	<button class="pushmaster-delay-request">Delay</button>
 	{% end %}
 
-	{% if pushmaster or request['user'] == current_user %}
+	{% if authorized_to_manage_request(request, current_user, pushmaster) %}
 	<button class="verify-request">Verify</button>
 	<button class="pickme-request">Pick me!</button>
 	<button class="unpickme-request">Don't pick me!</button>

--- a/templates/modules/request-buttons.html
+++ b/templates/modules/request-buttons.html
@@ -1,0 +1,35 @@
+{% if push_buttons %}
+<span class="push-request-buttons">
+
+	{% if pushmaster %}
+	<input type="checkbox" class="request-multi-select" />
+	<button class="add-request">Add</button>
+	<button class="remove-request">Remove</button>
+	<button class="comment-request">Comment</button>
+	<button class="pushmaster-delay-request">Delay</button>
+	{% end %}
+
+	{% if pushmaster or request['user'] == current_user %}
+	<button class="verify-request">Verify</button>
+	<button class="pickme-request">Pick me!</button>
+	<button class="unpickme-request">Don't pick me!</button>
+	{% end %}
+</span>
+{% elif edit_buttons %}
+<span class="edit-request-buttons">
+	<button class="edit-request">Edit</button>
+	{% if request['user'] == current_user %}
+
+		{% if request['state'] == 'requested' %}
+		<button class="delay-request">Delay</button>
+		{% elif request['state'] == 'delayed' %}
+		<button class="undelay-request">Un-Delay</button>
+		{% end %}
+
+		{% if request['state'] in ('requested', 'delayed') %}
+		<button class="discard-request">Discard</button>
+		{% end %}
+
+	{% end %}
+</span>
+{% end %}

--- a/templates/modules/request-info.html
+++ b/templates/modules/request-info.html
@@ -1,0 +1,35 @@
+<ul class="request-info-inline">
+
+	<li><span class="value">{{ escape(request['user']) }}</span></li>
+
+	{% if show_ago %}
+	<li><span class="value timeago">
+		{% if request['state'] in ('discarded', 'live') %}
+			{{ pretty_date(int(request['modified'])) }}
+		{% else %}
+			{{ pretty_date(int(request['created'])) }}
+		{% end %}
+	</span></li>
+	{% end %}
+
+	<li class="request-item-title">{{ escape(request['title']) }}</li>
+
+	{% if tags %}
+	<li><span class="value"><ul class="tags">
+		{% for (tag, tag_url) in tags %}<li class="tag-{{ escape(tag) }}">
+			{% if tag_url %}<a href="{{ escape(tag_url) }}">{{ escape(tag) }}</a>{% else %}{{ escape(tag) }}{% end %}
+		</li>{% end %}
+	</ul></span></li>
+	{% end %}
+
+	{% if show_state_inline %}
+	<li><span class="value">
+	{% if request['state'] in ('added','staged','verified', 'blessed', 'live') %}
+		<a href="/pushbyrequest?id={{ int(request['id']) }}"><em>{{ escape(request['state']) }}</em></a>
+	{% else %}
+		<em>{{ escape(request['state']) }}</em>
+	{% end %}
+	</span></li>
+	{% end %}
+
+</ul>

--- a/templates/modules/request-info.html
+++ b/templates/modules/request-info.html
@@ -1,6 +1,6 @@
 <ul class="request-info-inline">
 
-	<li><span class="value">{{ escape(request['user']) }}</span></li>
+	<li><span class="value">{{ escape(request['user']) }}{% if request['watchers'] %} ({{ escape(request['watchers']) }}){% end %}</span></li>
 
 	{% if show_ago %}
 	<li><span class="value timeago">

--- a/templates/modules/request.html
+++ b/templates/modules/request.html
@@ -4,6 +4,7 @@
 	repo="{{ escape(request['repo']) }}"
 	branch="{{ escape(request['branch']) }}"
 	user="{{ escape(request['user']) }}"
+	{% if request['watchers'] %}watchers="{{ escape(request['watchers']) }}"{% end %}
 	reviewid="{{ escape(str(request['reviewid'] or '')) }}"
 	request_title="{{ escape(request['title']) }}"
 	revision="{{ escape(request['revision']) }}"

--- a/templates/modules/request.html
+++ b/templates/modules/request.html
@@ -45,41 +45,7 @@
 </span>
 {% end %}
 
-<ul class="request-info-inline">
-
-	<li><span class="value">{{ escape(request['user']) }}</span></li>
-
-	{% if show_ago %}
-	<li><span class="value timeago">
-		{% if request['state'] in ('discarded', 'live') %}
-			{{ pretty_date(int(request['modified'])) }}
-		{% else %}
-			{{ pretty_date(int(request['created'])) }}
-		{% end %}
-	</span></li>
-	{% end %}
-
-	<li class="request-item-title">{{ escape(request['title']) }}</li>
-
-	{% if tags %}
-	<li><span class="value"><ul class="tags">
-		{% for (tag, tag_url) in tags %}<li class="tag-{{ escape(tag) }}">
-			{% if tag_url %}<a href="{{ escape(tag_url) }}">{{ escape(tag) }}</a>{% else %}{{ escape(tag) }}{% end %}
-		</li>{% end %}
-	</ul></span></li>
-	{% end %}
-
-	{% if show_state_inline %}
-	<li><span class="value">
-	{% if request['state'] in ('added','staged','verified', 'blessed', 'live') %}
-		<a href="/pushbyrequest?id={{ int(request['id']) }}"><em>{{ escape(request['state']) }}</em></a>
-	{% else %}
-		<em>{{ escape(request['state']) }}</em>
-	{% end %}
-	</span></li>
-	{% end %}
-
-</ul>
+{% include "request-info.html" %}
 
 <div class="request-info-extended">
 

--- a/templates/modules/request.html
+++ b/templates/modules/request.html
@@ -12,39 +12,7 @@
 
 <img src="{{ static_url('img/button_expand.gif') }}" class="request-item-expander" height="19" width="19" expand="{{ 'yes' if expand else 'no' }}" />
 
-{% if push_buttons %}
-<span class="push-request-buttons">
-
-	{% if pushmaster %}
-	<input type="checkbox" class="request-multi-select" />
-	<button class="add-request">Add</button>
-	<button class="remove-request">Remove</button>
-	<button class="comment-request">Comment</button>
-	<button class="pushmaster-delay-request">Delay</button>
-	{% end %}
-
-	<button class="verify-request">Verify</button>
-	<button class="pickme-request">Pick me!</button>
-	<button class="unpickme-request">Don't pick me!</button>
-</span>
-{% elif edit_buttons %}
-<span class="edit-request-buttons">
-	<button class="edit-request">Edit</button>
-	{% if request['user'] == current_user %}
-
-		{% if request['state'] == 'requested' %}
-		<button class="delay-request">Delay</button>
-		{% elif request['state'] == 'delayed' %}
-		<button class="undelay-request">Un-Delay</button>
-		{% end %}
-
-		{% if request['state'] in ('requested', 'delayed') %}
-		<button class="discard-request">Discard</button>
-		{% end %}
-
-	{% end %}
-</span>
-{% end %}
+{% include "request-buttons.html" %}
 
 {% include "request-info.html" %}
 

--- a/templates/push-status.html
+++ b/templates/push-status.html
@@ -16,7 +16,7 @@
 	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
 <ul id="pickme-items" class="push-items push-items-section">
 	{% for request in sorted(push_contents.get('pickme', []), key=lambda x: x['created']) %}
-	<li {% if authorized_to_manage_request(request, current_user) %}class="mine"{% end %}>
+	<li {% if authorized_to_manage_request(request, current_user) %}class="mine"{% end %} {% if push_info['user'] == current_user or override %}class="pushmaster"{% end %}>
 		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True, show_ago=True) }}
 	</li>
 	{% end %}

--- a/templates/push-status.html
+++ b/templates/push-status.html
@@ -5,7 +5,7 @@
 	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
 <ul id="{{ section }}-items" class="push-items push-items-section items-in-push">
 	{% for request in sorted(push_contents.get(section, []), key=lambda x: x['user']) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+	<li {% if authorized_to_manage_request(request, current_user) %}class="mine"{% end %}>
 		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True) }}
 	</li>
 	{% end %}
@@ -16,7 +16,7 @@
 	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
 <ul id="pickme-items" class="push-items push-items-section">
 	{% for request in sorted(push_contents.get('pickme', []), key=lambda x: x['created']) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+	<li {% if authorized_to_manage_request(request, current_user) %}class="mine"{% end %}>
 		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True, show_ago=True) }}
 	</li>
 	{% end %}
@@ -27,7 +27,7 @@
 <ul id="requested-items" class="push-items push-items-section">
 <p class="smalltext">Beginning with the oldest requests:</p>
 	{% for request in sorted(available_requests, key=lambda x: x['created']) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+	<li {% if authorized_to_manage_request(request, current_user) %}class="mine"{% end %}>
 		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True, show_ago=True) }}
 	</li>
 	{% end %}
@@ -37,7 +37,7 @@
 <h3 class="status-header">Included Requests ({{ len(push_contents.get('all', [])) }})</h3>
 <ul id="added-items" class="push-items push-items-section">
 	{% for request in push_contents.get('all', []) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+	<li {% if authorized_to_manage_request(request, current_user) %}class="mine"{% end %}>
 		{{ modules.Request(request) }}
 	</li>
 	{% end %}

--- a/templates/push-status.html
+++ b/templates/push-status.html
@@ -1,0 +1,45 @@
+<!-- ======== PUSH STATES ========= -->
+{% if push_info['state'] == 'accepting' %}
+{% for (section,sect_title) in [('blessed', 'Deployed to Prod'), ('verified', 'Verified on Stage'),	('staged', 'Deployed to Stage'), ('added', 'Added to Deploy Branch')] %}
+<h3 class="status-header" section="{{section}}">{{ sect_title }} <span class="item-count"></span>
+	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
+<ul id="{{ section }}-items" class="push-items push-items-section items-in-push">
+	{% for request in sorted(push_contents.get(section, []), key=lambda x: x['user']) %}
+	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True) }}
+	</li>
+	{% end %}
+</ul>
+{% end %}
+<!-- ========= PICKME ITEMS =========== -->
+<h3 class="status-header" section="pickme">Pick me, pick me! <span class="item-count"></span>
+	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
+<ul id="pickme-items" class="push-items push-items-section">
+	{% for request in sorted(push_contents.get('pickme', []), key=lambda x: x['created']) %}
+	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True, show_ago=True) }}
+	</li>
+	{% end %}
+</ul>
+<!-- ========= REQUESTED ITEMS  ========== -->
+<h3 class="status-header" section="requested">Open Requests <span class="item-count"></span>
+	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
+<ul id="requested-items" class="push-items push-items-section">
+<p class="smalltext">Beginning with the oldest requests:</p>
+	{% for request in sorted(available_requests, key=lambda x: x['created']) %}
+	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True, show_ago=True) }}
+	</li>
+	{% end %}
+</ul>
+{% else %}
+<!-- ========= ITEMS THAT WERE INCLUDED [CLOSED PUSH] ========== -->
+<h3 class="status-header">Included Requests ({{ len(push_contents.get('all', [])) }})</h3>
+<ul id="added-items" class="push-items push-items-section">
+	{% for request in push_contents.get('all', []) %}
+	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+		{{ modules.Request(request) }}
+	</li>
+	{% end %}
+</ul>
+{% end %}

--- a/templates/push.html
+++ b/templates/push.html
@@ -79,51 +79,9 @@
 		{% end %}
 	{% end %}
 </ul>
-<!-- ======== PUSH STATES ========= -->
-{% if push_info['state'] == 'accepting' %}
-{% for (section,sect_title) in [('blessed', 'Deployed to Prod'), ('verified', 'Verified on Stage'),	('staged', 'Deployed to Stage'), ('added', 'Added to Deploy Branch')] %}
-<h3 class="status-header" section="{{section}}">{{ sect_title }} <span class="item-count"></span>
-	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
-<ul id="{{ section }}-items" class="push-items push-items-section items-in-push">
-	{% for request in sorted(push_contents.get(section, []), key=lambda x: x['user']) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
-		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True) }}
-	</li>
-	{% end %}
-</ul>
-{% end %}
-<!-- ========= PICKME ITEMS =========== -->
-<h3 class="status-header" section="pickme">Pick me, pick me! <span class="item-count"></span>
-	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
-<ul id="pickme-items" class="push-items push-items-section">
-	{% for request in sorted(push_contents.get('pickme', []), key=lambda x: x['created']) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
-		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True, show_ago=True) }}
-	</li>
-	{% end %}
-</ul>
-<!-- ========= REQUESTED ITEMS  ========== -->
-<h3 class="status-header" section="requested">Open Requests <span class="item-count"></span>
-	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
-<ul id="requested-items" class="push-items push-items-section">
-<p class="smalltext">Beginning with the oldest requests:</p>
-	{% for request in sorted(available_requests, key=lambda x: x['created']) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
-		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True, show_ago=True) }}
-	</li>
-	{% end %}
-</ul>
-{% else %}
-<!-- ========= ITEMS THAT WERE INCLUDED [CLOSED PUSH] ========== -->
-<h3 class="status-header">Included Requests ({{ len(push_contents.get('all', [])) }})</h3>
-<ul id="added-items" class="push-items push-items-section">
-	{% for request in push_contents.get('all', []) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
-		{{ modules.Request(request) }}
-	</li>
-	{% end %}
-</ul>
-{% end %}
+
+{% include 'push-status.html' %}
+
 <div id="dialog-prototypes" style="display: none;">
 <!-- "Run a command" dialog -->
 	<div id="run-a-command">

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -8,6 +8,7 @@ from testify.__init__ import *
 from mocksettings import MockedSettings
 from testservlet import AsyncTestCase
 from testservlet import ServletTestMixin
+from testservlet import TemplateTestCase
 from testdb import *
 
 
@@ -15,5 +16,6 @@ __all__ = [
     AsyncTestCase,
     MockedSettings,
     testify,
-    ServletTestMixin
+    ServletTestMixin,
+    TemplateTestCase
 ]

--- a/testing/testdb.py
+++ b/testing/testdb.py
@@ -53,15 +53,15 @@ class FakeDataMixin(object):
     fake_revision = "0"*40
 
     request_data = [
-        [10, 'keysersoze', 'requested', 'keysersoze', 'usual_fix', '', now, now, 'Fix stuff', 'no comment', 12345, '', fake_revision],
-        [11, 'bmetin', 'requested', 'bmetin', 'fix1', '', now, now, 'Fixing more stuff', 'yes comment', 234, '', fake_revision],
-        [12, 'testuser1', 'requested', 'testuser2', 'fix1', 'search', now, now, 'Fixing1', 'no comment', 123, '', fake_revision],
-        [13, 'testuser2', 'requested', 'testuser2', 'fix2', 'search', now, now, 'Fixing2', 'yes comment', 456, '', fake_revision],
+        [10, 'keysersoze', 'requested', 'keysersoze', 'usual_fix', '', now, now, 'Fix stuff', 'no comment', 12345, '', fake_revision, ''],
+        [11, 'bmetin', 'requested', 'bmetin', 'fix1', '', now, now, 'Fixing more stuff', 'yes comment', 234, '', fake_revision, 'testuser3'],
+        [12, 'testuser1', 'requested', 'testuser2', 'fix1', 'search', now, now, 'Fixing1', 'no comment', 123, '', fake_revision, 'testuser3, testuser4'],
+        [13, 'testuser2', 'requested', 'testuser2', 'fix2', 'search', now, now, 'Fixing2', 'yes comment', 456, '', fake_revision, 'testuser5'],
 
     ]
     request_keys = [
         'id', 'user', 'state', 'repo', 'branch', 'tags', 'created', 'modified',
-        'title', 'comments', 'reviewid', 'description', 'revision'
+        'title', 'comments', 'reviewid', 'description', 'revision', 'watchers'
     ]
 
     def on_db_return(self, success, db_results):

--- a/testing/testdb.sql
+++ b/testing/testdb.sql
@@ -66,6 +66,7 @@ CREATE TABLE push_requests (
 	comments VARCHAR,
 	reviewid INTEGER,
 	description VARCHAR,
+	watchers VARCHAR,
 	PRIMARY KEY (id)
 );
 INSERT INTO "push_requests" VALUES(1,
@@ -82,7 +83,8 @@ INSERT INTO "push_requests" VALUES(1,
        NULL,
        'Ship it! from someone.
 
-This branch fixes stuff.'
+This branch fixes stuff.',
+       NULL
 );
 INSERT INTO "push_requests" VALUES(2,
        'bmetin',
@@ -96,7 +98,8 @@ INSERT INTO "push_requests" VALUES(2,
        'More fixes for important things',
        '',
        123,
-       'no comment'
+       'no comment',
+       NULL
 );
 INSERT INTO "push_requests" VALUES(3,
        'otheruser',
@@ -110,7 +113,8 @@ INSERT INTO "push_requests" VALUES(3,
        '',
        '',
        456,
-       ''
+       '',
+       NULL
 );
 CREATE TABLE push_checklist (
 	id INTEGER NOT NULL,

--- a/testing/testservlet.py
+++ b/testing/testservlet.py
@@ -1,15 +1,18 @@
 import logging
 import os
+import types
 
 import mock
 import tornado.web
 from lxml import etree
 from tornado.testing import AsyncHTTPTestCase
+from tornado.web import UIModule
 
 from core import db
 from core.requesthandler import RequestHandler
 from testify.utils import turtle
 import ui_modules
+import ui_methods
 import testing as T
 
 FORMAT = "%(asctime)-15s %(message)s"
@@ -35,6 +38,7 @@ class AsyncTestCase(AsyncHTTPTestCase):
             template_path = os.path.join(os.path.dirname(__file__), "../templates"),
             cookie_secret = 'cookie_secret',
             ui_modules = ui_modules,
+            ui_methods = ui_methods,
             autoescape = None,
         )
         return app
@@ -52,7 +56,14 @@ class TemplateTestCase(T.TestCase):
         application.settings = {
             'static_path': os.path.join(os.path.dirname(__file__), "../static"),
             'template_path': os.path.join(os.path.dirname(__file__), "../templates"),
+            'autoescape': None,
         }
+
+        application.ui_modules = {}
+        application.ui_methods = {}
+        self._load_ui_modules(application, ui_modules)
+        self._load_ui_methods(application, ui_methods)
+
         if self.authenticated:
             application.settings['cookie_secret'] = 'cookie_secret'
         request = turtle.Turtle()
@@ -63,6 +74,38 @@ class TemplateTestCase(T.TestCase):
         rendered_page = ''.join(self.servlet._write_buffer)
         tree = etree.HTML(rendered_page)
         return tree
+
+    # The following methods are lifted from tornado.web.Application
+    def _load_ui_methods(self, application, methods):
+        if type(methods) is types.ModuleType:
+            self._load_ui_methods(
+                    application,
+                    dict((n, getattr(methods, n)) for n in dir(methods)))
+        elif isinstance(methods, list):
+            for m in methods:
+                self._load_ui_methods(m)
+        else:
+            for name, fn in methods.iteritems():
+                if not name.startswith("_") and hasattr(fn, "__call__") \
+                   and name[0].lower() == name[0]:
+                    application.ui_methods[name] = fn
+
+    def _load_ui_modules(self, application, modules):
+        if type(modules) is types.ModuleType:
+            self._load_ui_modules(
+                    application,
+                    dict((n, getattr(modules, n)) for n in dir(modules)))
+        elif isinstance(modules, list):
+            for m in modules:
+                self._load_ui_modules(m)
+        else:
+            assert isinstance(modules, dict)
+            for name, cls in modules.iteritems():
+                try:
+                    if issubclass(cls, UIModule):
+                        application.ui_modules[name] = cls
+                except TypeError:
+                    pass
 
 
 class ServletTestMixin(AsyncTestCase):

--- a/testing/testservlet.py
+++ b/testing/testservlet.py
@@ -3,9 +3,12 @@ import os
 
 import mock
 import tornado.web
+from lxml import etree
 from tornado.testing import AsyncHTTPTestCase
 
 from core import db
+from core.requesthandler import RequestHandler
+from testify.utils import turtle
 import ui_modules
 import testing as T
 
@@ -35,6 +38,31 @@ class AsyncTestCase(AsyncHTTPTestCase):
             autoescape = None,
         )
         return app
+
+
+class TemplateTestCase(T.TestCase):
+    """Bare minimum setup to render and test templates"""
+    __test__ = False
+
+    authenticated = False
+
+    @T.setup
+    def setup_servlet(self):
+        application = turtle.Turtle()
+        application.settings = {
+            'static_path': os.path.join(os.path.dirname(__file__), "../static"),
+            'template_path': os.path.join(os.path.dirname(__file__), "../templates"),
+        }
+        if self.authenticated:
+            application.settings['cookie_secret'] = 'cookie_secret'
+        request = turtle.Turtle()
+        self.servlet = RequestHandler(application, request)
+
+    def render_etree(self, page, *args, **kwargs):
+        self.servlet.render(page, *args, **kwargs)
+        rendered_page = ''.join(self.servlet._write_buffer)
+        tree = etree.HTML(rendered_page)
+        return tree
 
 
 class ServletTestMixin(AsyncTestCase):

--- a/testing/testservlet.py
+++ b/testing/testservlet.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import logging
 import os
 import types
@@ -74,6 +75,13 @@ class TemplateTestCase(T.TestCase):
         rendered_page = ''.join(self.servlet._write_buffer)
         tree = etree.HTML(rendered_page)
         return tree
+
+    @contextmanager
+    def no_ui_modules(self):
+        modules = mock.Mock()
+        modules.Request = mock.Mock()
+        with mock.patch.dict(self.servlet.ui, modules=modules):
+            yield
 
     # The following methods are lifted from tornado.web.Application
     def _load_ui_methods(self, application, methods):

--- a/tests/test_servlet_blesspush.py
+++ b/tests/test_servlet_blesspush.py
@@ -1,14 +1,13 @@
 from contextlib import nested
 import mock
-import urllib
 
 from core import db
 from core.util import get_servlet_urlspec
-from servlets.addrequest import AddRequestServlet
+from servlets.blesspush import BlessPushServlet
 import testing as T
 import types
 
-class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
+class BlessPushServletTest(T.TestCase, T.ServletTestMixin):
 
     @T.class_setup_teardown
     def mock_servlet_env(self):
@@ -16,67 +15,15 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
         with nested(
             mock.patch.dict(db.Settings, T.MockedSettings),
             mock.patch.object(
-                AddRequestServlet,
+                BlessPushServlet,
                 "get_current_user",
                 return_value="testuser"
             )
         ):
             yield
 
-    def record_pushcontents(self, success, db_results):
-        assert success
-        self.results = []
-        self.results.extend(db_results.fetchall())
-
     def get_handlers(self):
-        return [get_servlet_urlspec(AddRequestServlet)]
-
-    def test_add_existing_request(self):
-        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
-        num_results_before = len(self.results)
-
-        request = { 'request': 1, 'push': 1 }
-        response = self.fetch(
-            '/addrequest',
-            method='POST',
-            body=urllib.urlencode(request)
-        )
-        T.assert_equal(response.error, None)
-
-        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
-        num_results_after = len(self.results)
-        T.assert_equal(num_results_after, num_results_before, "Add existing request failed.")
-
-    def test_add_new_request(self):
-        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
-        num_results_before = len(self.results)
-
-        request = { 'request': 2, 'push': 1 }
-        response = self.fetch(
-            '/addrequest',
-            method='POST',
-            body=urllib.urlencode(request)
-        )
-        T.assert_equal(response.error, None)
-
-        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
-        num_results_after = len(self.results)
-        T.assert_equal(num_results_after, num_results_before + 1, "Add new request failed.")
-
-    @mock.patch('core.db.execute_transaction_cb')
-    def test_pushcontent_insert_ignore(self, mock_transaction):
-        request = { 'request': 1, 'push': 1 }
-        response = self.fetch(
-            '/addrequest',
-            method='POST',
-            body=urllib.urlencode(request)
-        )
-        T.assert_equal(response.error, None)
-        T.assert_equal(mock_transaction.call_count, 1)
-
-        # Extract the string of the prefix of the insert query
-        insert_ignore_clause = mock_transaction.call_args[0][0][0]
-        T.assert_is(type(insert_ignore_clause), db.InsertIgnore)
+        return [get_servlet_urlspec(BlessPushServlet)]
 
     def call_on_db_complete(self):
         mocked_self = mock.Mock()
@@ -84,7 +31,7 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
         mocked_self.pushid = 0
         mocked_self.check_db_results = mock.Mock(return_value=None)
 
-        mocked_self.on_db_complete = types.MethodType(AddRequestServlet.on_db_complete.im_func, mocked_self)
+        mocked_self.on_db_complete = types.MethodType(BlessPushServlet.on_db_complete.im_func, mocked_self)
 
         no_watcher_req = {
             'user': 'testuser',
@@ -102,7 +49,14 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
         }
         reqs = [no_watcher_req, watched_req]
 
-        mocked_self.on_db_complete('success', [None, reqs])
+        def fetchone():
+            return {'extra_pings': None}
+
+        res = mock.Mock()
+        res.fetchone = fetchone
+
+        mocked_self.on_db_complete('success', [None, reqs, res])
+
 
     @mock.patch('core.xmppclient.XMPPQueue.enqueue_user_xmpp')
     @mock.patch('core.mail.MailQueue.enqueue_user_email')
@@ -111,13 +65,13 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
 
         no_watcher_call_args = mailq.call_args_list[0][0]
         T.assert_equal(['testuser'], no_watcher_call_args[0])
-        T.assert_in('for testuser', no_watcher_call_args[1])
+        T.assert_in('request for testuser', no_watcher_call_args[1])
         T.assert_in('testuser - title', no_watcher_call_args[1])
         T.assert_in('[push] testuser - title', no_watcher_call_args[2])
 
         watched_call_args = mailq.call_args_list[1][0]
         T.assert_equal(['testuser', 'testuser1', 'testuser2'], watched_call_args[0])
-        T.assert_in('for testuser (testuser1,testuser2)', watched_call_args[1])
+        T.assert_in('request for testuser (testuser1,testuser2)', watched_call_args[1])
         T.assert_in('testuser (testuser1,testuser2) - title', watched_call_args[1])
         T.assert_in('[push] testuser (testuser1,testuser2) - title', watched_call_args[2])
 
@@ -128,6 +82,7 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
 
         no_watcher_call_args = xmppq.call_args_list[0][0]
         T.assert_equal(['testuser'], no_watcher_call_args[0])
+        T.assert_in('for testuser', no_watcher_call_args[1])
         T.assert_in('for testuser', no_watcher_call_args[1])
 
         watched_call_args = xmppq.call_args_list[1][0]

--- a/tests/test_servlet_delayrequest.py
+++ b/tests/test_servlet_delayrequest.py
@@ -1,0 +1,81 @@
+from contextlib import nested
+import mock
+
+from core import db
+from core.util import get_servlet_urlspec
+from servlets.delayrequest import DelayRequestServlet
+import testing as T
+import types
+
+class DelayRequestServletTest(T.TestCase, T.ServletTestMixin):
+
+    @T.class_setup_teardown
+    def mock_servlet_env(self):
+        self.results = []
+        with nested(
+            mock.patch.dict(db.Settings, T.MockedSettings),
+            mock.patch.object(
+                DelayRequestServlet,
+                "get_current_user",
+                return_value="testuser"
+            )
+        ):
+            yield
+
+    def get_handlers(self):
+        return [get_servlet_urlspec(DelayRequestServlet)]
+
+    def call_on_db_complete(self, req):
+        mocked_self = mock.Mock()
+        mocked_self.current_user = 'fake_pushmaster'
+        mocked_self.check_db_results = mock.Mock(return_value=None)
+
+        mocked_self.on_db_complete = types.MethodType(DelayRequestServlet.on_db_complete.im_func, mocked_self)
+
+        def first():
+            return req
+
+        mreq = mock.Mock()
+        mreq.first = first
+
+        mocked_self.on_db_complete('success', [mock.ANY, mock.ANY, mreq])
+
+    @mock.patch('core.mail.MailQueue.enqueue_user_email')
+    def test_no_watched_mailqueue_on_db_complete(self, mailq):
+        req = {
+            'user': 'testuser',
+            'watchers': None,
+            'repo': 'repo',
+            'branch': 'branch',
+            'title': 'title',
+            'state': 'delayed',
+        }
+        self.call_on_db_complete(req)
+
+        no_watcher_call_args = mailq.call_args_list[0][0]
+        T.assert_equal(['testuser'], no_watcher_call_args[0])
+        T.assert_in('Request for testuser', no_watcher_call_args[1])
+        T.assert_in('testuser - title', no_watcher_call_args[1])
+        T.assert_in('[push] testuser - title', no_watcher_call_args[2])
+
+    @mock.patch('core.mail.MailQueue.enqueue_user_email')
+    def test_watched_mailqueue_on_db_complete(self, mailq):
+        req = {
+            'user': 'testuser',
+            'watchers': 'testuser1,testuser2',
+            'repo': 'repo',
+            'branch': 'branch',
+            'title': 'title',
+            'state': 'delayed',
+        }
+        self.call_on_db_complete(req)
+
+        watched_call_args = mailq.call_args_list[0][0]
+        T.assert_equal(['testuser', 'testuser1', 'testuser2'], watched_call_args[0])
+        T.assert_in('Request for testuser (testuser1,testuser2)', watched_call_args[1])
+        T.assert_in('testuser (testuser1,testuser2) - title', watched_call_args[1])
+        T.assert_in('[push] testuser (testuser1,testuser2) - title', watched_call_args[2])
+
+
+if __name__ == '__main__':
+    T.run()

--- a/tests/test_servlet_deploypush.py
+++ b/tests/test_servlet_deploypush.py
@@ -1,14 +1,13 @@
 from contextlib import nested
 import mock
-import urllib
 
 from core import db
 from core.util import get_servlet_urlspec
-from servlets.addrequest import AddRequestServlet
+from servlets.deploypush import DeployPushServlet
 import testing as T
 import types
 
-class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
+class DeployPushServletTest(T.TestCase, T.ServletTestMixin):
 
     @T.class_setup_teardown
     def mock_servlet_env(self):
@@ -16,67 +15,15 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
         with nested(
             mock.patch.dict(db.Settings, T.MockedSettings),
             mock.patch.object(
-                AddRequestServlet,
+                DeployPushServlet,
                 "get_current_user",
                 return_value="testuser"
             )
         ):
             yield
 
-    def record_pushcontents(self, success, db_results):
-        assert success
-        self.results = []
-        self.results.extend(db_results.fetchall())
-
     def get_handlers(self):
-        return [get_servlet_urlspec(AddRequestServlet)]
-
-    def test_add_existing_request(self):
-        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
-        num_results_before = len(self.results)
-
-        request = { 'request': 1, 'push': 1 }
-        response = self.fetch(
-            '/addrequest',
-            method='POST',
-            body=urllib.urlencode(request)
-        )
-        T.assert_equal(response.error, None)
-
-        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
-        num_results_after = len(self.results)
-        T.assert_equal(num_results_after, num_results_before, "Add existing request failed.")
-
-    def test_add_new_request(self):
-        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
-        num_results_before = len(self.results)
-
-        request = { 'request': 2, 'push': 1 }
-        response = self.fetch(
-            '/addrequest',
-            method='POST',
-            body=urllib.urlencode(request)
-        )
-        T.assert_equal(response.error, None)
-
-        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
-        num_results_after = len(self.results)
-        T.assert_equal(num_results_after, num_results_before + 1, "Add new request failed.")
-
-    @mock.patch('core.db.execute_transaction_cb')
-    def test_pushcontent_insert_ignore(self, mock_transaction):
-        request = { 'request': 1, 'push': 1 }
-        response = self.fetch(
-            '/addrequest',
-            method='POST',
-            body=urllib.urlencode(request)
-        )
-        T.assert_equal(response.error, None)
-        T.assert_equal(mock_transaction.call_count, 1)
-
-        # Extract the string of the prefix of the insert query
-        insert_ignore_clause = mock_transaction.call_args[0][0][0]
-        T.assert_is(type(insert_ignore_clause), db.InsertIgnore)
+        return [get_servlet_urlspec(DeployPushServlet)]
 
     def call_on_db_complete(self):
         mocked_self = mock.Mock()
@@ -84,7 +31,7 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
         mocked_self.pushid = 0
         mocked_self.check_db_results = mock.Mock(return_value=None)
 
-        mocked_self.on_db_complete = types.MethodType(AddRequestServlet.on_db_complete.im_func, mocked_self)
+        mocked_self.on_db_complete = types.MethodType(DeployPushServlet.on_db_complete.im_func, mocked_self)
 
         no_watcher_req = {
             'user': 'testuser',
@@ -102,7 +49,13 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
         }
         reqs = [no_watcher_req, watched_req]
 
-        mocked_self.on_db_complete('success', [None, reqs])
+        def fetchone():
+            return {'extra_pings': None}
+
+        res = mock.Mock()
+        res.fetchone = fetchone
+
+        mocked_self.on_db_complete('success', [None, reqs, res])
 
     @mock.patch('core.xmppclient.XMPPQueue.enqueue_user_xmpp')
     @mock.patch('core.mail.MailQueue.enqueue_user_email')
@@ -111,13 +64,13 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
 
         no_watcher_call_args = mailq.call_args_list[0][0]
         T.assert_equal(['testuser'], no_watcher_call_args[0])
-        T.assert_in('for testuser', no_watcher_call_args[1])
+        T.assert_in('request for testuser', no_watcher_call_args[1])
         T.assert_in('testuser - title', no_watcher_call_args[1])
         T.assert_in('[push] testuser - title', no_watcher_call_args[2])
 
         watched_call_args = mailq.call_args_list[1][0]
         T.assert_equal(['testuser', 'testuser1', 'testuser2'], watched_call_args[0])
-        T.assert_in('for testuser (testuser1,testuser2)', watched_call_args[1])
+        T.assert_in('request for testuser (testuser1,testuser2)', watched_call_args[1])
         T.assert_in('testuser (testuser1,testuser2) - title', watched_call_args[1])
         T.assert_in('[push] testuser (testuser1,testuser2) - title', watched_call_args[2])
 

--- a/tests/test_servlet_discardrequest.py
+++ b/tests/test_servlet_discardrequest.py
@@ -1,0 +1,81 @@
+from contextlib import nested
+import mock
+
+from core import db
+from core.util import get_servlet_urlspec
+from servlets.discardrequest import DiscardRequestServlet
+import testing as T
+import types
+
+class DiscardRequestServletTest(T.TestCase, T.ServletTestMixin):
+
+    @T.class_setup_teardown
+    def mock_servlet_env(self):
+        self.results = []
+        with nested(
+            mock.patch.dict(db.Settings, T.MockedSettings),
+            mock.patch.object(
+                DiscardRequestServlet,
+                "get_current_user",
+                return_value="testuser"
+            )
+        ):
+            yield
+
+    def get_handlers(self):
+        return [get_servlet_urlspec(DiscardRequestServlet)]
+
+    def call_on_db_complete(self, req):
+        mocked_self = mock.Mock()
+        mocked_self.current_user = 'fake_pushmaster'
+        mocked_self.check_db_results = mock.Mock(return_value=None)
+
+        mocked_self.on_db_complete = types.MethodType(DiscardRequestServlet.on_db_complete.im_func, mocked_self)
+
+        def first():
+            return req
+
+        mreq = mock.Mock()
+        mreq.first = first
+
+        mocked_self.on_db_complete('success', [mock.ANY, mreq])
+
+    @mock.patch('core.mail.MailQueue.enqueue_user_email')
+    def test_no_watched_mailqueue_on_db_complete(self, mailq):
+        req = {
+            'user': 'testuser',
+            'watchers': None,
+            'repo': 'repo',
+            'branch': 'branch',
+            'title': 'title',
+            'state': 'discarded',
+        }
+        self.call_on_db_complete(req)
+
+        no_watcher_call_args = mailq.call_args_list[0][0]
+        T.assert_equal(['testuser'], no_watcher_call_args[0])
+        T.assert_in('Request for testuser', no_watcher_call_args[1])
+        T.assert_in('testuser - title', no_watcher_call_args[1])
+        T.assert_in('[push] testuser - title', no_watcher_call_args[2])
+
+    @mock.patch('core.mail.MailQueue.enqueue_user_email')
+    def test_watched_mailqueue_on_db_complete(self, mailq):
+        req = {
+            'user': 'testuser',
+            'watchers': 'testuser1,testuser2',
+            'repo': 'repo',
+            'branch': 'branch',
+            'title': 'title',
+            'state': 'discarded',
+        }
+        self.call_on_db_complete(req)
+
+        watched_call_args = mailq.call_args_list[0][0]
+        T.assert_equal(['testuser', 'testuser1', 'testuser2'], watched_call_args[0])
+        T.assert_in('Request for testuser (testuser1,testuser2)', watched_call_args[1])
+        T.assert_in('testuser (testuser1,testuser2) - title', watched_call_args[1])
+        T.assert_in('[push] testuser (testuser1,testuser2) - title', watched_call_args[2])
+
+
+if __name__ == '__main__':
+    T.run()

--- a/tests/test_servlet_livepush.py
+++ b/tests/test_servlet_livepush.py
@@ -1,0 +1,73 @@
+from contextlib import nested
+import mock
+
+from core import db
+from core.util import get_servlet_urlspec
+from servlets.livepush import LivePushServlet
+import testing as T
+import types
+
+class LivePushServletTest(T.TestCase, T.ServletTestMixin):
+
+    @T.class_setup_teardown
+    def mock_servlet_env(self):
+        self.results = []
+        with nested(
+            mock.patch.dict(db.Settings, T.MockedSettings),
+            mock.patch.object(
+                LivePushServlet,
+                "get_current_user",
+                return_value="testuser"
+            )
+        ):
+            yield
+
+    def get_handlers(self):
+        return [get_servlet_urlspec(LivePushServlet)]
+
+    def call_on_db_complete(self):
+        mocked_self = mock.Mock()
+        mocked_self.current_user = 'fake_pushmaster'
+        mocked_self.check_db_results = mock.Mock(return_value=None)
+
+        mocked_self.on_db_complete = types.MethodType(LivePushServlet.on_db_complete.im_func, mocked_self)
+
+        no_watcher_req = {
+            'user': 'testuser',
+            'watchers': None,
+            'repo': 'repo',
+            'branch': 'branch',
+            'title': 'title',
+            'reviewid': 0,
+        }
+        watched_req = {
+            'user': 'testuser',
+            'watchers': 'testuser1,testuser2',
+            'repo': 'repo',
+            'branch': 'branch',
+            'title': 'title',
+            'reviewid': 0,
+        }
+        reqs = [no_watcher_req, watched_req]
+
+        mocked_self.on_db_complete('success', [None, None, None, None, reqs])
+
+    @mock.patch('core.mail.MailQueue.enqueue_user_email')
+    def test_mailqueue_on_db_complete(self, mailq):
+        self.call_on_db_complete()
+
+        no_watcher_call_args = mailq.call_args_list[0][0]
+        T.assert_equal(['testuser'], no_watcher_call_args[0])
+        T.assert_in('request for testuser', no_watcher_call_args[1])
+        T.assert_in('testuser - title', no_watcher_call_args[1])
+        T.assert_in('[push] testuser - title', no_watcher_call_args[2])
+
+        watched_call_args = mailq.call_args_list[1][0]
+        T.assert_equal(['testuser', 'testuser1', 'testuser2'], watched_call_args[0])
+        T.assert_in('request for testuser (testuser1,testuser2)', watched_call_args[1])
+        T.assert_in('testuser (testuser1,testuser2) - title', watched_call_args[1])
+        T.assert_in('[push] testuser (testuser1,testuser2) - title', watched_call_args[2])
+
+
+if __name__ == '__main__':
+    T.run()

--- a/tests/test_servlet_newrequest.py
+++ b/tests/test_servlet_newrequest.py
@@ -42,6 +42,7 @@ class NewRequestServletTest(T.TestCase, T.ServletTestMixin, T.FakeDataMixin):
                 'request-branch': 'super_safe_fix',
                 'request-comments': 'No comment',
                 'request-description': 'I approve this fix!',
+                'request-watchers': 'testuser2,testuser3',
             }
 
             response = self.fetch(
@@ -65,6 +66,7 @@ class NewRequestServletTest(T.TestCase, T.ServletTestMixin, T.FakeDataMixin):
             T.assert_equal(request['request-tags'], last_req['tags'])
             T.assert_equal(request['request-comments'], last_req['comments'])
             T.assert_equal(request['request-description'], last_req['description'])
+            T.assert_equal(request['request-watchers'], last_req['watchers'])
 
 
 class NewRequestChecklistMixin(T.ServletTestMixin, T.FakeDataMixin):

--- a/tests/test_servlet_newrequest.py
+++ b/tests/test_servlet_newrequest.py
@@ -246,4 +246,4 @@ class EditRequestChecklistTest(T.TestCase, NewRequestChecklistMixin):
         T.assert_equal(orig_reqid, new_reqid)
 
 if __name__ == '__main__':
-	T.run()
+    T.run()

--- a/tests/test_servlet_removerequest.py
+++ b/tests/test_servlet_removerequest.py
@@ -1,5 +1,6 @@
 from contextlib import nested
 import mock
+import types
 
 from core import db
 from core.util import get_servlet_urlspec
@@ -39,3 +40,70 @@ class RemoveRequestServletTest(T.TestCase, T.ServletTestMixin):
             num_results_after = len(results)
 
             T.assert_equal(num_results_after, num_results_before - 1, "Request removal failed.")
+
+    def call_on_db_complete(self):
+        mocked_self = mock.Mock()
+        mocked_self.current_user = 'fake_pushmaster'
+        mocked_self.pushid = 0
+        mocked_self.check_db_results = mock.Mock(return_value=None)
+
+        mocked_self.on_db_complete = types.MethodType(RemoveRequestServlet.on_db_complete.im_func, mocked_self)
+
+        no_watcher_req = {
+            'id': 0,
+            'user': 'testuser',
+            'watchers': None,
+            'repo': 'repo',
+            'branch': 'branch',
+            'title': 'title',
+            'state': 'added',
+        }
+        watched_req = {
+            'id': 0,
+            'user': 'testuser',
+            'watchers': 'testuser1,testuser2',
+            'repo': 'repo',
+            'branch': 'branch',
+            'title': 'title',
+            'state': 'added',
+        }
+        reqs = [no_watcher_req, watched_req]
+
+        mocked_self.on_db_complete('success', [reqs, mock.ANY, mock.ANY])
+
+    @mock.patch('core.db.execute_transaction_cb')
+    @mock.patch('core.xmppclient.XMPPQueue.enqueue_user_xmpp')
+    @mock.patch('core.mail.MailQueue.enqueue_user_email')
+    def test_mailqueue_on_db_complete(self, mailq, *_):
+        self.call_on_db_complete()
+
+        no_watcher_call_args = mailq.call_args_list[0][0]
+        T.assert_equal(['testuser'], no_watcher_call_args[0])
+        T.assert_in('for testuser', no_watcher_call_args[1])
+        T.assert_in('testuser - title', no_watcher_call_args[1])
+        T.assert_in('[push] testuser - title', no_watcher_call_args[2])
+
+        watched_call_args = mailq.call_args_list[1][0]
+        T.assert_equal(['testuser', 'testuser1', 'testuser2'], watched_call_args[0])
+        T.assert_in('for testuser (testuser1,testuser2)', watched_call_args[1])
+        T.assert_in('testuser (testuser1,testuser2) - title', watched_call_args[1])
+        T.assert_in('[push] testuser (testuser1,testuser2) - title', watched_call_args[2])
+
+
+    @mock.patch('core.db.execute_transaction_cb')
+    @mock.patch('core.mail.MailQueue.enqueue_user_email')
+    @mock.patch('core.xmppclient.XMPPQueue.enqueue_user_xmpp')
+    def test_xmppqueue_on_db_complete(self, xmppq, *_):
+        self.call_on_db_complete()
+
+        no_watcher_call_args = xmppq.call_args_list[0][0]
+        T.assert_equal(['testuser'], no_watcher_call_args[0])
+        T.assert_in('for testuser', no_watcher_call_args[1])
+
+        watched_call_args = xmppq.call_args_list[1][0]
+        T.assert_equal(['testuser', 'testuser1', 'testuser2'], watched_call_args[0])
+        T.assert_in('for testuser (testuser1,testuser2)', watched_call_args[1])
+
+
+if __name__ == '__main__':
+    T.run()

--- a/tests/test_template_newrequest.py
+++ b/tests/test_template_newrequest.py
@@ -1,0 +1,42 @@
+import testing as T
+
+class NewRequestTemplateTest(T.TemplateTestCase):
+
+    authenticated = True
+    newrequest_page = 'modules/newrequest.html'
+
+    form_elements = ['title', 'tags', 'review', 'repo', 'branch', 'description', 'comments', 'watchers']
+
+    def test_request_form_labels(self):
+        tree = self.render_etree(self.newrequest_page)
+
+        for_attr = ['request-form-%s' % elem for elem in self.form_elements]
+
+        found_labels = []
+        for label in tree.iter('label'):
+            found_labels.append(label.attrib['for'])
+
+        T.assert_sorted_equal(for_attr, found_labels)
+
+    def test_request_form_input(self):
+        tree = self.render_etree(self.newrequest_page)
+
+        id_attr = ['request-form-%s' % elem for elem in self.form_elements]
+        name_attr = ['request-%s' % elem for elem in self.form_elements]
+
+        found_id = []
+        found_name = []
+        for field in tree.iter('input'):
+            if 'type' not in field.attrib:  # ignore hidden/submit
+                found_id.append(field.attrib['id'])
+                found_name.append(field.attrib['name'])
+
+        for textarea in tree.iter('textarea'):
+            found_id.append(textarea.attrib['id'])
+            found_name.append(textarea.attrib['name'])
+
+        T.assert_sorted_equal(id_attr, found_id)
+        T.assert_sorted_equal(name_attr, found_name)
+
+if __name__ == '__main__':
+    T.run()

--- a/tests/test_template_newrequest.py
+++ b/tests/test_template_newrequest.py
@@ -10,13 +10,13 @@ class NewRequestTemplateTest(T.TemplateTestCase):
     def test_request_form_labels(self):
         tree = self.render_etree(self.newrequest_page)
 
-        for_attr = ['request-form-%s' % elem for elem in self.form_elements]
+        form_attr = ['request-form-%s' % elem for elem in self.form_elements]
 
         found_labels = []
         for label in tree.iter('label'):
             found_labels.append(label.attrib['for'])
 
-        T.assert_sorted_equal(for_attr, found_labels)
+        T.assert_sorted_equal(form_attr, found_labels)
 
     def test_request_form_input(self):
         tree = self.render_etree(self.newrequest_page)

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -1,0 +1,64 @@
+import time
+
+import testing as T
+
+class PushTemplateTest(T.TemplateTestCase):
+
+    authenticated = True
+    push_page = 'push.html'
+
+    accepting_push_sections = ['blessed', 'verified', 'staged', 'added', 'pickme', 'requested']
+
+    basic_push = {
+            'id': 0,
+            'user': 'pushmaster',
+            'title': 'fake_push',
+            'branch': 'deploy-fake-branch',
+            'state': 'accepting',
+            'pushtype': 'Normal',
+            'created': 23423423,
+            'modified': 2342432423,
+            'extra_pings': None,
+        }
+
+    basic_kwargs = {
+            'page_title': 'fake_push_title',
+            'push_contents': {},
+            'available_requests': [],
+            'fullrepo': 'not/a/repo',
+            'override': False
+            }
+
+    def test_include_push_status_when_accepting(self):
+        tree = self.render_etree(
+            self.push_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+
+        found_h3 = []
+        for h3 in tree.iter('h3'):
+            T.assert_equal('status-header', h3.attrib['class'])
+            T.assert_in(h3.attrib['section'], self.accepting_push_sections)
+            found_h3.append(h3)
+
+        T.assert_equal(len(self.accepting_push_sections), len(found_h3))
+
+    def test_include_push_status_when_done(self):
+        push = dict(self.basic_push)
+        push['state'] = 'live'
+
+        tree = self.render_etree(
+            self.push_page,
+            push_info=push,
+            **self.basic_kwargs)
+
+        found_h3 = []
+        for h3 in tree.iter('h3'):
+            T.assert_equal('status-header', h3.attrib['class'])
+            found_h3.append(h3)
+
+        T.assert_equal(1, len(found_h3))
+
+
+if __name__ == '__main__':
+    T.run()

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -6,8 +6,11 @@ class PushTemplateTest(T.TemplateTestCase):
 
     authenticated = True
     push_page = 'push.html'
+    push_status_page = 'push-status.html'
 
     accepting_push_sections = ['blessed', 'verified', 'staged', 'added', 'pickme', 'requested']
+
+    now = time.time()
 
     basic_push = {
             'id': 0,
@@ -15,9 +18,9 @@ class PushTemplateTest(T.TemplateTestCase):
             'title': 'fake_push',
             'branch': 'deploy-fake-branch',
             'state': 'accepting',
-            'pushtype': 'Normal',
-            'created': 23423423,
-            'modified': 2342432423,
+            'pushtype': 'Regular',
+            'created': now,
+            'modified': now,
             'extra_pings': None,
         }
 
@@ -27,6 +30,23 @@ class PushTemplateTest(T.TemplateTestCase):
             'available_requests': [],
             'fullrepo': 'not/a/repo',
             'override': False
+            }
+
+    basic_request = {
+            'id': 0,
+            'repo': 'non-existent',
+            'branch': 'non-existent',
+            'user': 'testuser',
+            'reviewid': 0,
+            'title': 'some title',
+            'tags': None,
+            'revision': '0' * 40,
+            'state': 'requested',
+            'created': now,
+            'modified': now,
+            'description': 'nondescript',
+            'comments': 'nocomment',
+            'watchers': None,
             }
 
     def test_include_push_status_when_accepting(self):
@@ -58,6 +78,115 @@ class PushTemplateTest(T.TemplateTestCase):
             found_h3.append(h3)
 
         T.assert_equal(1, len(found_h3))
+
+    def generate_push_contents(self, requests):
+        push_contents = dict.fromkeys(self.accepting_push_sections, [])
+        for section in self.accepting_push_sections:
+            push_contents[section] = requests
+        return push_contents
+
+    def test_no_mine_on_requests_as_random_user(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['push_contents'] = self.generate_push_contents([self.basic_request])
+        kwargs['current_user'] = 'random_user'
+
+        with self.no_ui_modules():
+            tree = self.render_etree(
+                self.push_status_page,
+                push_info=self.basic_push,
+                **kwargs)
+
+        found_mockreq = []
+        for mockreq in tree.iter('mock'):
+            T.assert_not_in('class', mockreq.getparent().attrib.keys())
+            found_mockreq.append(mockreq)
+
+        T.assert_equal(5, len(found_mockreq))
+
+    def test_mine_on_requests_as_request_user(self):
+        request = dict(self.basic_request)
+        request['user'] = 'notme'
+
+        push_contents = {}
+        section_id = []
+        for section in self.accepting_push_sections:
+            push_contents[section] = [self.basic_request, request]
+            section_id.append('%s-items' % section)
+
+        kwargs = dict(self.basic_kwargs)
+        kwargs['push_contents'] = push_contents
+        kwargs['current_user'] = 'testuser'
+
+        with self.no_ui_modules():
+            tree = self.render_etree(
+                self.push_status_page,
+                push_info=self.basic_push,
+                **kwargs)
+
+        found_li = []
+        found_mockreq = []
+        for mockreq in tree.iter('mock'):
+            if 'class' in mockreq.getparent().attrib:
+                T.assert_equal('mine', mockreq.getparent().attrib['class'])
+                found_li.append(mockreq)
+            found_mockreq.append(mockreq)
+
+        T.assert_equal(5, len(found_li))
+        T.assert_equal(10, len(found_mockreq))
+
+    def test_mine_on_requests_as_watcher(self):
+        request = dict(self.basic_request)
+        request['watchers'] = 'watcher1'
+
+        push_contents = {}
+        section_id = []
+        for section in self.accepting_push_sections:
+            push_contents[section] = [request, self.basic_request]
+            section_id.append('%s-items' % section)
+
+        kwargs = dict(self.basic_kwargs)
+        kwargs['push_contents'] = push_contents
+        kwargs['current_user'] = 'watcher1'
+
+        with self.no_ui_modules():
+            tree = self.render_etree(
+                self.push_status_page,
+                push_info=self.basic_push,
+                **kwargs)
+
+        found_li = []
+        found_mockreq = []
+        for mockreq in tree.iter('mock'):
+            if 'class' in mockreq.getparent().attrib:
+                T.assert_equal('mine', mockreq.getparent().attrib['class'])
+                found_li.append(mockreq)
+            found_mockreq.append(mockreq)
+
+        T.assert_equal(5, len(found_li))
+        T.assert_equal(10, len(found_mockreq))
+
+    def test_mine_on_requests_as_pushmaster(self):
+        push_contents = {}
+        section_id = []
+        for section in self.accepting_push_sections:
+            push_contents[section] = [self.basic_request]
+            section_id.append('%s-items' % section)
+
+        kwargs = dict(self.basic_kwargs)
+        kwargs['push_contents'] = push_contents
+
+        with self.no_ui_modules():
+            tree = self.render_etree(
+                self.push_status_page,
+                push_info=self.basic_push,
+                **kwargs)
+
+        found_mockreq = []
+        for mockreq in tree.iter('mock'):
+            T.assert_not_in('class', mockreq.getparent().attrib.keys())
+            found_mockreq.append(mockreq)
+
+        T.assert_equal(5, len(found_mockreq))
 
 
 if __name__ == '__main__':

--- a/tests/test_template_request.py
+++ b/tests/test_template_request.py
@@ -57,6 +57,35 @@ class RequestTemplateTest(T.TemplateTestCase):
 
         T.assert_equal(1, len(found_ul))
 
+    def test_request_info_user_title(self):
+        request = {
+            'id': 0,
+            'repo': 'non-existent',
+            'branch': 'non-existent',
+            'user': 'testuser',
+            'reviewid': 0,
+            'title': 'some title',
+            'revision': '0' * 40,
+            'state': 'requested',
+            'created': 'nodate',
+            'modified': 'nodate',
+            'description': 'nondescript',
+            'comments': 'nocomment',
+            'watchers': 'watcher1, watcher2',
+        }
+
+        tree = self.render_etree(self.request_info_page,
+            request=request,
+            show_ago=False,
+            tags=None,
+            show_state_inline=False)
+
+        # user names are listed in the first li of the list
+        # <ul><li><span>title</span></li> ... </ul>
+        title = list(tree.iter('li'))[0][0].text
+
+        T.assert_equal(title, '%s (%s)' % (request['user'], request['watchers']))
+
 
 if __name__ == '__main__':
     T.run()

--- a/tests/test_template_request.py
+++ b/tests/test_template_request.py
@@ -6,13 +6,10 @@ class RequestTemplateTest(T.TemplateTestCase):
     request_page = 'modules/request.html'
     request_info_page = 'modules/request-info.html'
 
-    def render_module_request_with_users(self, request_user, current_user, pushmaster=False):
-        """Provide enough information to render modules/request"""
-        request = {
+    basic_request = {
             'id': 0,
             'repo': 'non-existent',
             'branch': 'non-existent',
-            'user': request_user,
             'reviewid': 0,
             'title': 'some title',
             'revision': '0' * 40,
@@ -21,34 +18,53 @@ class RequestTemplateTest(T.TemplateTestCase):
             'modified': 'nodate',
             'description': 'nondescript',
             'comments': 'nocomment',
-            'watchers': 'watcher1, watcher2',
-        }
+            'watchers': None,
+            }
 
-        web_hooks = {
-            'service_name': 'noname',
-            'get_request_url': 'non://existent',
-        }
+    basic_kwargs = {
+            'pushmaster': False,
+            'web_hooks': {
+                'service_name': 'noname',
+                'get_request_url': 'non://existent',
+                },
+            'cherry_string': '',
+            'expand': False,
+            'push_buttons': False,
+            'edit_buttons': False,
+            'show_ago': False,
+            'tags': None,
+            'show_state_inline': False,
+            'review': None,
+            'repo_url': 'non://existent',
+            'branch_url': 'non://existent',
+            'create_time': 'nodate'
+            }
+
+
+    def render_module_request_with_users(self, request, request_user, current_user, **kwargs):
+        """Provide enough information to render modules/request"""
+        request['user'] = request_user
 
         return self.render_etree(self.request_page,
-            pushmaster=pushmaster,
             current_user=current_user,
             request=request,
-            web_hooks=web_hooks,
-            cherry_string='',
-            expand=False,
-            push_buttons=True,
-            edit_buttons=False,
-            show_ago=False,
-            tags=None,
-            show_state_inline=False,
-            review=None,
-            repo_url='non://existent',
-            branch_url='non://existent',
-            create_time='nodate',
+            **kwargs
         )
 
+    def assert_button_link(self, button, tree, text=None, num=1):
+        classname = '%s-request' % button.lower()
+        if text is None:
+            text = button.capitalize()
+
+        buttons = []
+        for button in tree.iter('button'):
+            if button.attrib['class'] == classname:
+                T.assert_equal(text, button.text)
+                buttons.append(button)
+        T.assert_equal(num, len(buttons))
+
     def test_include_request_info(self):
-        tree = self.render_module_request_with_users('testuser', 'testuser')
+        tree = self.render_module_request_with_users(self.basic_request,'testuser', 'testuser', **self.basic_kwargs)
 
         found_ul = []
         for ul in tree.iter('ul'):
@@ -58,21 +74,8 @@ class RequestTemplateTest(T.TemplateTestCase):
         T.assert_equal(1, len(found_ul))
 
     def test_request_info_user_title(self):
-        request = {
-            'id': 0,
-            'repo': 'non-existent',
-            'branch': 'non-existent',
-            'user': 'testuser',
-            'reviewid': 0,
-            'title': 'some title',
-            'revision': '0' * 40,
-            'state': 'requested',
-            'created': 'nodate',
-            'modified': 'nodate',
-            'description': 'nondescript',
-            'comments': 'nocomment',
-            'watchers': 'watcher1, watcher2',
-        }
+        request = dict(self.basic_request)
+        request['watchers'] = 'watcher1, watcher2'
 
         tree = self.render_etree(self.request_info_page,
             request=request,

--- a/tests/test_template_request.py
+++ b/tests/test_template_request.py
@@ -89,6 +89,111 @@ class RequestTemplateTest(T.TemplateTestCase):
 
         T.assert_equal(title, '%s (%s)' % (request['user'], request['watchers']))
 
+    def test_include_no_request_buttons(self):
+        tree = self.render_module_request_with_users(self.basic_request, 'testuser', 'testuser', **self.basic_kwargs)
+
+        for span in tree.iter('span'):
+            T.assert_not_equal('push-request-buttons', span.attrib['class'])
+            T.assert_not_equal('edit-request-buttons', span.attrib['class'])
+
+    def test_include_push_buttons(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['push_buttons'] = True
+
+        tree = self.render_module_request_with_users(self.basic_request, 'testuser', 'testuser', **kwargs)
+
+        found_span = []
+        for span in tree.iter('span'):
+            T.assert_not_equal('edit-request-buttons', span.attrib['class'])
+            if span.attrib['class'] == 'push-request-buttons':
+                found_span.append(span)
+
+        T.assert_equal(1, len(found_span))
+
+    def test_include_edit_buttons(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['edit_buttons'] = True
+
+        tree = self.render_module_request_with_users(self.basic_request, 'testuser', 'testuser', **kwargs)
+
+        found_span = []
+        for span in tree.iter('span'):
+            T.assert_not_equal('push-request-buttons', span.attrib['class'])
+            if span.attrib['class'] == 'edit-request-buttons':
+                found_span.append(span)
+
+        T.assert_equal(1, len(found_span))
+
+    pushmaster_button_classes = ['add-request', 'remove-request', 'comment-request', 'pushmaster-delay-request']
+    pushmaster_button_text = ['Add', 'Remove', 'Comment', 'Delay']
+    push_button_classes = ['verify-request', 'pickme-request', 'unpickme-request']
+    push_button_text = ['Verify', 'Pick me!', 'Don\'t pick me!']
+    requester_edit_button_classes = ['edit-request', 'delay-request', 'discard-request']
+    requester_edit_button_text = ['Edit', 'Delay', 'Discard']
+    edit_button_classes = ['edit-request']
+    edit_button_text = ['Edit']
+
+    def assert_request_buttons(self, tree, button_classes, button_text):
+        found_buttons = []
+        for button in tree.iter('button'):
+            T.assert_in(button.attrib['class'], button_classes)
+            T.assert_in(button.text, button_text)
+            found_buttons.append(button)
+        T.assert_equal(len(button_classes), len(found_buttons))
+
+    def test_request_push_buttons_as_random_user(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['push_buttons'] = True
+
+        tree = self.render_module_request_with_users(self.basic_request, 'testuser', 'notuser', **kwargs)
+
+        buttons_found = []
+        for button in tree.iter('button'):
+            T.assert_not_in(button.attrib['class'], self.pushmaster_button_classes + self.push_button_classes)
+            buttons_found.append(button)
+
+        T.assert_equal(0, len(buttons_found))
+
+    def test_request_push_buttons_as_request_user(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['push_buttons'] = True
+
+        tree = self.render_module_request_with_users(self.basic_request, 'testuser', 'testuser', **kwargs)
+        self.assert_request_buttons(tree, self.push_button_classes, self.push_button_text)
+
+    def test_request_push_buttons_as_pushmaster(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['push_buttons'] = True
+        kwargs['pushmaster'] = True
+
+        tree = self.render_module_request_with_users(self.basic_request, 'testuser', 'notuser', **kwargs)
+        self.assert_request_buttons(
+            tree,
+            self.pushmaster_button_classes + self.push_button_classes,
+            self.pushmaster_button_text + self.push_button_text)
+
+    def test_request_edit_buttons_as_random_user(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['edit_buttons'] = True
+
+        tree = self.render_module_request_with_users(self.basic_request, 'testuser', 'notuser', **kwargs)
+        self.assert_request_buttons(tree, self.edit_button_classes, self.edit_button_text)
+
+    def test_request_edit_buttons_as_request_user(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['edit_buttons'] = True
+
+        tree = self.render_module_request_with_users(self.basic_request, 'testuser', 'testuser', **kwargs)
+        self.assert_request_buttons(tree, self.requester_edit_button_classes, self.requester_edit_button_text)
+
+    def test_request_edit_buttons_as_pushmaster(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['edit_buttons'] = True
+        kwargs['pushmaster'] = True
+
+        tree = self.render_module_request_with_users(self.basic_request, 'testuser', 'notuser', **kwargs)
+        self.assert_request_buttons(tree, self.edit_button_classes, self.edit_button_text)
+
 
 if __name__ == '__main__':
     T.run()

--- a/tests/test_template_request.py
+++ b/tests/test_template_request.py
@@ -1,0 +1,62 @@
+import testing as T
+
+class RequestTemplateTest(T.TemplateTestCase):
+
+    authenticated = True
+    request_page = 'modules/request.html'
+    request_info_page = 'modules/request-info.html'
+
+    def render_module_request_with_users(self, request_user, current_user, pushmaster=False):
+        """Provide enough information to render modules/request"""
+        request = {
+            'id': 0,
+            'repo': 'non-existent',
+            'branch': 'non-existent',
+            'user': request_user,
+            'reviewid': 0,
+            'title': 'some title',
+            'revision': '0' * 40,
+            'state': 'requested',
+            'created': 'nodate',
+            'modified': 'nodate',
+            'description': 'nondescript',
+            'comments': 'nocomment',
+            'watchers': 'watcher1, watcher2',
+        }
+
+        web_hooks = {
+            'service_name': 'noname',
+            'get_request_url': 'non://existent',
+        }
+
+        return self.render_etree(self.request_page,
+            pushmaster=pushmaster,
+            current_user=current_user,
+            request=request,
+            web_hooks=web_hooks,
+            cherry_string='',
+            expand=False,
+            push_buttons=True,
+            edit_buttons=False,
+            show_ago=False,
+            tags=None,
+            show_state_inline=False,
+            review=None,
+            repo_url='non://existent',
+            branch_url='non://existent',
+            create_time='nodate',
+        )
+
+    def test_include_request_info(self):
+        tree = self.render_module_request_with_users('testuser', 'testuser')
+
+        found_ul = []
+        for ul in tree.iter('ul'):
+            if ul.attrib['class'] == 'request-info-inline':
+                found_ul.append(ul)
+
+        T.assert_equal(1, len(found_ul))
+
+
+if __name__ == '__main__':
+    T.run()

--- a/tests/test_template_request.py
+++ b/tests/test_template_request.py
@@ -172,6 +172,19 @@ class RequestTemplateTest(T.TemplateTestCase):
             self.pushmaster_button_classes + self.push_button_classes,
             self.pushmaster_button_text + self.push_button_text)
 
+    def test_request_push_buttons_as_watchers(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['push_buttons'] = True
+
+        request = dict(self.basic_request)
+        request['watchers'] = 'watcher1'
+
+        tree = self.render_module_request_with_users(request, 'testuser', 'watcher1', **kwargs)
+        self.assert_request_buttons(
+            tree,
+            self.push_button_classes,
+            self.push_button_text)
+
     def test_request_edit_buttons_as_random_user(self):
         kwargs = dict(self.basic_kwargs)
         kwargs['edit_buttons'] = True
@@ -192,6 +205,16 @@ class RequestTemplateTest(T.TemplateTestCase):
         kwargs['pushmaster'] = True
 
         tree = self.render_module_request_with_users(self.basic_request, 'testuser', 'notuser', **kwargs)
+        self.assert_request_buttons(tree, self.edit_button_classes, self.requester_edit_button_text)
+
+    def test_request_edit_buttons_as_watchers(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['edit_buttons'] = True
+
+        request = dict(self.basic_request)
+        request['watchers'] = 'watcher1'
+
+        tree = self.render_module_request_with_users(request, 'testuser', 'watcher1', **kwargs)
         self.assert_request_buttons(tree, self.edit_button_classes, self.edit_button_text)
 
 

--- a/tests/test_ui_methods.py
+++ b/tests/test_ui_methods.py
@@ -1,0 +1,25 @@
+import testing as T
+
+from ui_methods import authorized_to_manage_request
+
+class UIMethodTest(T.TestCase):
+
+    def test_authorized_to_manage_request_random_user(self):
+        request = {'user': 'testuser', 'watchers': None }
+        T.assert_equal(False, authorized_to_manage_request(None, request, 'notme'))
+
+    def test_authorized_to_manage_request_request_user(self):
+        request = {'user': 'testuser', 'watchers': None }
+        T.assert_equal(True, authorized_to_manage_request(None, request, 'testuser'))
+
+    def test_authorized_to_manage_request_pushmaster(self):
+        request = {'user': 'testuser', 'watchers': None }
+        T.assert_equal(True, authorized_to_manage_request(None, request, 'notme', True))
+
+    def test_authorized_to_manage_request_watcher(self):
+        request = {'user': 'testuser', 'watchers': 'watcher1' }
+        T.assert_equal(True, authorized_to_manage_request(None, request, 'watcher1'))
+
+
+if __name__ == '__main__':
+    T.run()

--- a/ui_methods.py
+++ b/ui_methods.py
@@ -1,0 +1,6 @@
+def authorized_to_manage_request(_, request, current_user, pushmaster=False):
+    if pushmaster or \
+       request['user'] == current_user or \
+       (request['watchers'] and current_user in request['watchers'].split(',')):
+        return True
+    return False


### PR DESCRIPTION
A watcher or list of watchers can be assigned to pull requests. Watchers are listed as alternate owners of the request and are pinged wherever the original requester would be pinged.

This PR includes a new test framework for templates. In doing so, some templates were refactored for easier template testing.

Unfortunately, the javascript changes do not have automatic tests. They have been verified through smoke testing with a local test instance and IRC.

Note: This also encompasses the feature request in PR #16
