### PR TITLE
Make addrequest work for sqlite3

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -169,3 +169,9 @@ def execute_transaction_cb(queries, callback_fn, condition=None):
     finally:
         callback_fn(success, results)
         conn.close()
+
+def add_ignore_clause(query):
+    if Settings["db_uri"].startswith("sqlite"):
+        return query.prefix_with('OR IGNORE')
+    else:
+        return query.prefix_with('IGNORE')

--- a/core/db.py
+++ b/core/db.py
@@ -3,7 +3,9 @@ import logging
 import sqlalchemy as SA
 from sqlalchemy.dialects import mysql
 from sqlalchemy import Column, Integer, SmallInteger, String
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.sql.expression import Insert
 
 from core.settings import Settings
 
@@ -170,8 +172,13 @@ def execute_transaction_cb(queries, callback_fn, condition=None):
         callback_fn(success, results)
         conn.close()
 
-def add_ignore_clause(query):
-    if Settings["db_uri"].startswith("sqlite"):
-        return query.prefix_with('OR IGNORE')
-    else:
-        return query.prefix_with('IGNORE')
+class InsertIgnore(Insert):
+    pass
+
+@compiles(InsertIgnore)
+def prefix_insert_ignore(insert_ignore, compiler, **kw):
+    return  compiler.visit_insert(insert_ignore.prefix_with('IGNORE'), **kw)
+
+@compiles(InsertIgnore, 'sqlite')
+def prefix_insert_ignore_sqlite(insert_ignore, compiler, **kw):
+    return  compiler.visit_insert(insert_ignore.prefix_with('OR IGNORE'), **kw)

--- a/servlets/addrequest.py
+++ b/servlets/addrequest.py
@@ -1,4 +1,5 @@
 import core.db as db
+from core.db import InsertIgnore
 from core.mail import MailQueue
 from core.requesthandler import RequestHandler
 from core.settings import Settings
@@ -14,10 +15,9 @@ class AddRequestServlet(RequestHandler):
         self.request_ids = self.request.arguments.get('request', [])
 
         insert_queries = [
-                db.add_ignore_clause(
-                    db.push_pushcontents.insert({'request':int(i), 'push':self.pushid})
-                    )
-                for i in self.request_ids]
+                InsertIgnore(db.push_pushcontents, ({'request': int(i), 'push': self.pushid}))
+                for i in self.request_ids
+        ]
         update_query = db.push_requests.update().where(
             db.push_requests.c.id.in_(self.request_ids)).values({'state':'added'})
         request_query = db.push_requests.select().where(

--- a/servlets/addrequest.py
+++ b/servlets/addrequest.py
@@ -13,9 +13,13 @@ class AddRequestServlet(RequestHandler):
         self.pushid = core.util.get_int_arg(self.request, 'push')
         self.request_ids = self.request.arguments.get('request', [])
 
-        insert_queries = [
-            db.push_pushcontents.insert({'request':int(i), 'push':self.pushid}).prefix_with('IGNORE')
-            for i in self.request_ids]
+        insert_queries = []
+        for i in self.request_ids:
+            if Settings["db_uri"].startswith("sqlite"):
+                query = db.push_pushcontents.insert({'request':int(i), 'push':self.pushid}).prefix_with('OR IGNORE')
+            else:
+                query = db.push_pushcontents.insert({'request':int(i), 'push':self.pushid}).prefix_with('IGNORE')
+            insert_queries.append(query)
         update_query = db.push_requests.update().where(
             db.push_requests.c.id.in_(self.request_ids)).values({'state':'added'})
         request_query = db.push_requests.select().where(

--- a/tests/test_servlet_addrequest.py
+++ b/tests/test_servlet_addrequest.py
@@ -1,0 +1,63 @@
+from contextlib import nested
+import mock
+import urllib
+
+from core import db
+from core.util import get_servlet_urlspec
+from servlets.addrequest import AddRequestServlet
+import testing as T
+
+class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
+
+    @T.class_setup_teardown
+    def mock_servlet_env(self):
+        self.results = []
+        with nested(
+            mock.patch.dict(db.Settings, T.MockedSettings),
+            mock.patch.object(
+                AddRequestServlet,
+                "get_current_user",
+                return_value="testuser"
+            )
+        ):
+            yield
+
+    def record_pushcontents(self, success, db_results):
+        assert success
+        self.results = []
+        self.results.extend(db_results.fetchall())
+
+    def get_handlers(self):
+        return [get_servlet_urlspec(AddRequestServlet)]
+
+    def test_add_existing_request(self):
+        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
+        num_results_before = len(self.results)
+
+        request = { 'request': 1, 'push': 1 }
+        response = self.fetch(
+            '/addrequest',
+            method='POST',
+            body=urllib.urlencode(request)
+        )
+        T.assert_equal(response.error, None)
+
+        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
+        num_results_after = len(self.results)
+        T.assert_equal(num_results_after, num_results_before, "Add existing request failed.")
+
+    def test_add_new_request(self):
+        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
+        num_results_before = len(self.results)
+
+        request = { 'request': 2, 'push': 1 }
+        response = self.fetch(
+            '/addrequest',
+            method='POST',
+            body=urllib.urlencode(request)
+        )
+        T.assert_equal(response.error, None)
+
+        db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
+        num_results_after = len(self.results)
+        T.assert_equal(num_results_after, num_results_before + 1, "Add new request failed.")

--- a/tests/test_servlet_addrequest.py
+++ b/tests/test_servlet_addrequest.py
@@ -63,7 +63,7 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
         T.assert_equal(num_results_after, num_results_before + 1, "Add new request failed.")
 
     @mock.patch('core.db.execute_transaction_cb')
-    def test_puscontent_insert_ignore_sqlite(self, mock_transaction):
+    def test_pushcontent_insert_ignore(self, mock_transaction):
         request = { 'request': 1, 'push': 1 }
         response = self.fetch(
             '/addrequest',
@@ -74,19 +74,5 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
         T.assert_equal(mock_transaction.call_count, 1)
 
         # Extract the string of the prefix of the insert query
-        T.assert_equal(mock_transaction.call_args[0][0][0]._prefixes[0].text, 'OR IGNORE')
-
-    @mock.patch('core.db.execute_transaction_cb')
-    @mock.patch.dict(db.Settings, {'db_uri': 'mysql://'})
-    def test_puscontent_insert_ignore_mysql(self, mock_transaction):
-        request = { 'request': 1, 'push': 1 }
-        response = self.fetch(
-            '/addrequest',
-            method='POST',
-            body=urllib.urlencode(request)
-        )
-        T.assert_equal(response.error, None)
-        T.assert_equal(mock_transaction.call_count, 1)
-
-        # Extract the string of the prefix of the insert query
-        T.assert_equal(mock_transaction.call_args[0][0][0]._prefixes[0].text, 'IGNORE')
+        insert_ignore_clause = mock_transaction.call_args[0][0][0]
+        T.assert_is(type(insert_ignore_clause), db.InsertIgnore)

--- a/tests/test_servlet_addrequest.py
+++ b/tests/test_servlet_addrequest.py
@@ -61,3 +61,32 @@ class AddRequestServletTest(T.TestCase, T.ServletTestMixin):
         db.execute_cb(db.push_pushcontents.select(), self.record_pushcontents)
         num_results_after = len(self.results)
         T.assert_equal(num_results_after, num_results_before + 1, "Add new request failed.")
+
+    @mock.patch('core.db.execute_transaction_cb')
+    def test_puscontent_insert_ignore_sqlite(self, mock_transaction):
+        request = { 'request': 1, 'push': 1 }
+        response = self.fetch(
+            '/addrequest',
+            method='POST',
+            body=urllib.urlencode(request)
+        )
+        T.assert_equal(response.error, None)
+        T.assert_equal(mock_transaction.call_count, 1)
+
+        # Extract the string of the prefix of the insert query
+        T.assert_equal(mock_transaction.call_args[0][0][0]._prefixes[0].text, 'OR IGNORE')
+
+    @mock.patch('core.db.execute_transaction_cb')
+    @mock.patch.dict(db.Settings, {'db_uri': 'mysql://'})
+    def test_puscontent_insert_ignore_mysql(self, mock_transaction):
+        request = { 'request': 1, 'push': 1 }
+        response = self.fetch(
+            '/addrequest',
+            method='POST',
+            body=urllib.urlencode(request)
+        )
+        T.assert_equal(response.error, None)
+        T.assert_equal(mock_transaction.call_count, 1)
+
+        # Extract the string of the prefix of the insert query
+        T.assert_equal(mock_transaction.call_args[0][0][0]._prefixes[0].text, 'IGNORE')


### PR DESCRIPTION
MySQL supports INSERT IGNORE
SQLITE3 (used for tesitng) uses INSERT OR IGNORE

This patch makes the ignore clause conditional on the db_uri
