### PR TITLE
Explicit stage

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -60,6 +60,7 @@ class PushPushes(Base):
     modified = Column(Integer, nullable=True)
     pushtype = Column(String)
     extra_pings = Column(String)
+    stageenv = Column(String, nullable=True)
 
 
 class PushRemovals(Base):

--- a/core/util.py
+++ b/core/util.py
@@ -172,6 +172,7 @@ def push_to_jsonable(push):
             'title',
             'user',
             'branch',
+            'stageenv',
             'state',
             'created',
             'modified',

--- a/pushmanager_main.py
+++ b/pushmanager_main.py
@@ -47,6 +47,7 @@ from servlets.userlist import UserListServlet
 from servlets.verifyrequest import VerifyRequestServlet
 
 import ui_modules
+import ui_methods
 
 class NullRequestHandler(RequestHandler):
     def get(self): pass
@@ -169,6 +170,7 @@ class PushManagerApp(Application):
             login_url = "/login",
             cookie_secret = Settings['cookie_secret'],
             ui_modules = ui_modules,
+            ui_methods = ui_methods,
             autoescape = None,
         )
 

--- a/servlets/editpush.py
+++ b/servlets/editpush.py
@@ -18,6 +18,7 @@ class EditPushServlet(RequestHandler):
             'user': self.current_user,
             'branch': self._arg('push-branch'),
             'revision': "0"*40,
+            'stageenv': self._arg('push-stageenv'),
             'modified': time.time(),
             })
         db.execute_cb(

--- a/static/js/push.js
+++ b/static/js/push.js
@@ -320,20 +320,59 @@ $(function() {
         $('.request-item-expander').attr('src', "/static/img/button_expand.gif");
     });
 
-    $('#deploy-to-stage').click(function() {
+    $('#set-stageenv-prompt').dialog({
+        autoOpen: false,
+        modal: true,
+        title: 'Set stage environment:',
+        width: 300,
+        height: 150
+    });
+    PushManager.set_stageenv_dialog = function(env) {
+        if (env == '') {
+            $('#set-stageenv').attr('disabled', 'true');
+        }
+        $('#set-stageenv-contents').val(env);
+        $('#set-stageenv-contents').keyup(function(){
+            if ($(this).val() != '') {
+                $('#set-stageenv').removeAttr('disabled');
+            } else {
+                $('#set-stageenv').attr('disabled', 'true');
+            }});
+        $('#set-stageenv-prompt').dialog('open');
+    }
+
+    $('#deploy-to-stage-step0').click(function() {
+        PushManager.set_stageenv_dialog($('#push-info').attr('stageenv'))
+    });
+
+    $('#set-stageenv').click(function() {
         var that = $(this);
-        PushManager.run_command_dialog("deploy-stage --target <stagename> -b " + $('#push-info').attr('branch'), function() {
-            // "Cancel" button was not pressed, so mark as deployed to stage
-            $.ajax({
-                'type': 'POST',
-                'url': '/deploypush',
-                'data': {'id': $('#push-info').attr('push')},
-                'success': function() {
-                    $("#added-items").children().detach().appendTo('#staged-items');
-                    setTimeout('PushManager.update_status_counts()', 50);
-                },
-                'error': function() { alert("Something went wrong when marking the newly added items as staged."); }
-            });
+        $.ajax({
+            'url': '/editpush',
+            'type': 'POST',
+            'data': {
+                'id': $('#push-info').attr('push'),
+                'push-title': $('#push-info').attr('title'),
+                'push-branch': $('#push-info').attr('branch'),
+                'push-stageenv': $('#set-stageenv-contents').val()
+            },
+            'success' : function() {
+                $('#set-stageenv-prompt').dialog('close');
+                $('#push-info').attr('stageenv', $('#set-stageenv-contents').val());
+                PushManager.run_command_dialog("deploy-stage --target " + $('#push-info').attr('stageenv') + " -b " + $('#push-info').attr('branch'), function() {
+                    // "Cancel" button was not pressed, so mark as deployed to stage
+                    $.ajax({
+                        'type': 'POST',
+                        'url': '/deploypush',
+                        'data': {'id': $('#push-info').attr('push')},
+                        'success': function() {
+                            $("#added-items").children().detach().appendTo('#staged-items');
+                            setTimeout('PushManager.update_status_counts()', 50);
+                        },
+                        'error': function() { alert("Something went wrong when marking the newly added items as staged."); }
+                    });
+                });
+            }
         });
     });
 

--- a/templates/edit-push.html
+++ b/templates/edit-push.html
@@ -9,6 +9,9 @@
 	<label for="push-branch">Branch</label>
 	<input name="push-branch" id="push-branch" value="{{ escape(push_info['branch']) }}" />
 
+	<label for="push-stageenv">Stage Environment</label>
+	<input name="push-stageenv" id="push-stageenv" value="{% if push_info['stageenv'] %}{{ escape(push_info['stageenv']) }}{% end %}" />
+
 	<input type="hidden" name="id" value="{{ int(push_info['id']) }}" />
 
 	{% if not push_info['user'] == current_user %}

--- a/templates/edit-push.html
+++ b/templates/edit-push.html
@@ -1,0 +1,23 @@
+<form id="push-info-form" class="popup-form" action="/editpush" method="POST">
+<div class="form-wrapper">
+
+	<h2>Edit Push</h2>
+
+	<label for="push-title">Title</label>
+	<input name="push-title" id="push-title" value="{{ escape(push_info['title']) }}" />
+
+	<label for="push-branch">Branch</label>
+	<input name="push-branch" id="push-branch" value="{{ escape(push_info['branch']) }}" />
+
+	<input type="hidden" name="id" value="{{ int(push_info['id']) }}" />
+
+	{% if not push_info['user'] == current_user %}
+	<p id="update-notice">Updating this push will transfer its ownership to you.</p>
+	{% end %}
+
+	<div class="buttons">
+		<input type="submit" id="push-create" name="push-submit" value="Update Push" />
+		<input type="reset" id="push-cancel" name="push-cancel" value="Cancel" />
+	</div>
+</div>
+</form>

--- a/templates/new-push.html
+++ b/templates/new-push.html
@@ -1,0 +1,25 @@
+<form id="push-info-form" class="popup-form" action="/newpush" method="POST">
+<div class="form-wrapper">
+
+	<h2>New Push</h2>
+
+	<label for="push-title">Title</label>
+	<input name="push-title" id="push-title" />
+
+	<label for="push-branch">Branch</label>
+	<input name="push-branch" id="push-branch" value="deploy-branch-with-descriptive-name" />
+
+	<label for="push-type">Push Type</label>
+	<select name="push-type" id="push-type">
+		<option selected="selected" value="regular">Regular</option>
+		<option value="urgent">Urgent (P0-only)</option>
+		<option value="morning">Morning (Use 'Regular' if it's already morning)</option>
+		<option value="private">Private (By invitation only)</option>
+	</select>
+
+	<div class="buttons">
+		<input type="submit" id="push-create" name="push-submit" value="Create Push" />
+		<input type="reset" id="push-cancel" name="push-cancel" value="Cancel" />
+	</div>
+</div>
+</form>

--- a/templates/push-button-bar.html
+++ b/templates/push-button-bar.html
@@ -17,7 +17,7 @@
 		<li><button id="remove-selected-requests">Remove Selected</button></li>
 		<li><button id="rebuild-deploy-branch">Rebuild Deploy Branch</button></li>
 		&mdash;
-		<li><button id="deploy-to-stage">Added &rarr; Stage</button></li>
+		<li><button id="deploy-to-stage-step0">Added &rarr; Stage</button></li>
 		<li><button id="deploy-to-prod">Stage &rarr; Prod</button></li>
 		<li><button id="merge-to-master">Prod &rarr; master</button></li>
 		&mdash;

--- a/templates/push-button-bar.html
+++ b/templates/push-button-bar.html
@@ -1,0 +1,32 @@
+<ul id="action-buttons">
+	<li><button id="expand-all-requests">Expand All</button></li>
+	<li><button id="collapse-all-requests">Collapse All</button></li>
+	&mdash;
+	{% if current_user in (push_info['extra_pings'] or []) %}
+	<li><button id="ping-me" action="unset">Don't Ping Me</button></li>
+	{% else %}
+	<li><button id="ping-me" action="set">Ping Me</button></li>
+	{% end %}
+	{% if push_info['user'] == current_user or override %}
+		&mdash;
+		<li><button id="edit-push">Edit Push</button></li>
+		{% if push_info['state'] == 'accepting' %}
+		<li><button id="discard-push">Discard Push</button></li>
+		&mdash;
+		<li><button id="add-selected-requests">Add Selected</button></li>
+		<li><button id="remove-selected-requests">Remove Selected</button></li>
+		<li><button id="rebuild-deploy-branch">Rebuild Deploy Branch</button></li>
+		&mdash;
+		<li><button id="deploy-to-stage">Added &rarr; Stage</button></li>
+		<li><button id="deploy-to-prod">Stage &rarr; Prod</button></li>
+		<li><button id="merge-to-master">Prod &rarr; master</button></li>
+		&mdash;
+		<li><button id="message-all">Message All</button></li>
+		<li><button id="show-checklist">Push Checklist</button></li>
+		{% end %}
+	{% else %}
+		{% if push_info['state'] == 'accepting' %}
+		&mdash; <li><button id="edit-push">Takeover Push</button></li>
+		{% end %}
+	{% end %}
+</ul>

--- a/templates/push-dialogs.html
+++ b/templates/push-dialogs.html
@@ -52,4 +52,12 @@
 			<button id="send-message">Send</button>
 		</p>
 	</div>
+<!-- Stage Environment dialog -->
+	<div id="set-stageenv-prompt">
+		<input id="set-stageenv-contents" />
+		<p class="directions">
+			Enter the stage environment for this push, then
+			<button id="set-stageenv">Continue</button>
+		</p>
+	</div>
 </div>

--- a/templates/push-dialogs.html
+++ b/templates/push-dialogs.html
@@ -1,0 +1,55 @@
+<div id="dialog-prototypes" style="display: none;">
+<!-- "Run a command" dialog -->
+	<div id="run-a-command">
+		<pre id="command-to-run">&nbsp;</pre>
+		<p class="directions">
+			Wait for it to complete, then
+			<button id="command-done">Continue</button>
+		</p>
+		<p class="mininote">
+			(If it fails, click the X or press Esc.)
+		</p>
+	</div>
+<!-- "Comment on a request" dialog -->
+	<div id="comment-on-request">
+		<textarea id="comment-input-area"></textarea>
+		<p class="directions">
+			Enter your comment here, then
+			<button id="submit-request-comment">Submit</button>
+		</p>
+	</div>
+<!-- "Check in multiple requests" dialog -->
+	<div id="merge-requests">
+		<div class="command" id="merge-branches-command">&nbsp;</div>
+		<p class="dialog-note">(Triple-click above to easily select the entire command for copying.)</p>
+		<p class="directions">
+			Once the command completes, click <button id="done-merging">here</button>
+		</p>
+	</div>
+<!-- Push checklist dialog -->
+	<div id="push-checklist">
+		<h4>Before Staging</h4>
+		<ul id="checklist-before-staging">
+			<li><input type="checkbox" /> Foo</li>
+			<li><input type="checkbox" /> Foo</li>
+		</ul>
+		<h4>Before Blessing</h4>
+		<ul id="checklist-before-blessing">
+			<li><input type="checkbox" /> Foo</li>
+			<li><input type="checkbox" /> Foo</li>
+		</ul>
+		<h4>After Live</h4>
+		<ul id="checklist-after-live">
+			<li><input type="checkbox" /> Foo</li>
+			<li><input type="checkbox" /> Foo</li>
+		</ul>
+	</div>
+<!-- Messaging dialog -->
+	<div id="send-message-prompt">
+		<input id="send-message-contents" />
+		<p class="directions">
+			Enter the message you wish to send here, then
+			<button id="send-message">Send</button>
+		</p>
+	</div>
+</div>

--- a/templates/push-info.html
+++ b/templates/push-info.html
@@ -1,0 +1,17 @@
+<ul id="push-info" class="push-info standalone" push="{{ int(push_info['id']) }}" pushmaster="{{ escape(push_info['user']) }}" branch="{{ escape(push_info['branch']) }}">
+	<li><span class="label">Pushmaster</span><span class="value">{{ escape(push_info['user']) }}</span></li>
+	<li><span class="label">Branch</span><span class="value">{{ escape(push_info['branch']) }}</span></li>
+{% if push_info['state'] == 'accepting' %}
+	<li><span class="label">Buildbot Runs</span><span class="value"><a href="http://{{ escape(Settings['buildbot']['servername']) }}/branch/{{ escape(push_info['branch']) }}">url</a></span></li>
+{% end %}
+	<li><span class="label">State</span><span class="value"><ul class="tags">
+			<li class="tag-{{ escape(push_info['state']) }}">{{ escape(push_info['state']) }}</li>
+		</ul></span></li>
+	<li><span class="label">Push Type</span><span class="value"><ul class="tags">
+			<li class="tag-{{ escape(push_info['pushtype']) }}">{{ escape(push_info['pushtype']) }}</li>
+		</ul></span></li>
+	<li><span class="label">Created</span><span class="value">{{ datetime.datetime.fromtimestamp(push_info['created']).strftime("%x %X") }}</span></li>
+{% if not push_info['created'] == push_info['modified'] %}
+	<li><span class="label">Modified</span><span class="value">{{ datetime.datetime.fromtimestamp(push_info['modified']).strftime("%x %X") }}</span></li>
+{% end %}
+</ul>

--- a/templates/push-info.html
+++ b/templates/push-info.html
@@ -1,6 +1,7 @@
-<ul id="push-info" class="push-info standalone" push="{{ int(push_info['id']) }}" pushmaster="{{ escape(push_info['user']) }}" branch="{{ escape(push_info['branch']) }}">
+<ul id="push-info" class="push-info standalone" push="{{ int(push_info['id']) }}" pushmaster="{{ escape(push_info['user']) }}" branch="{{ escape(push_info['branch']) }}" stageenv="{% if push_info['stageenv'] %}{{ escape(push_info['stageenv']) }}{% end %}">
 	<li><span class="label">Pushmaster</span><span class="value">{{ escape(push_info['user']) }}</span></li>
 	<li><span class="label">Branch</span><span class="value">{{ escape(push_info['branch']) }}</span></li>
+	{% if push_info['stageenv'] %}<li><span class="label">Stage</span><span class="value">{{ escape(push_info['stageenv']) }}</span></li>{% end %}
 {% if push_info['state'] == 'accepting' %}
 	<li><span class="label">Buildbot Runs</span><span class="value"><a href="http://{{ escape(Settings['buildbot']['servername']) }}/branch/{{ escape(push_info['branch']) }}">url</a></span></li>
 {% end %}

--- a/templates/push-status.html
+++ b/templates/push-status.html
@@ -1,0 +1,45 @@
+<!-- ======== PUSH STATES ========= -->
+{% if push_info['state'] == 'accepting' %}
+{% for (section,sect_title) in [('blessed', 'Deployed to Prod'), ('verified', 'Verified on Stage'),	('staged', 'Deployed to Stage'), ('added', 'Added to Deploy Branch')] %}
+<h3 class="status-header" section="{{section}}">{{ sect_title }} <span class="item-count"></span>
+	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
+<ul id="{{ section }}-items" class="push-items push-items-section items-in-push">
+	{% for request in sorted(push_contents.get(section, []), key=lambda x: x['user']) %}
+	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True) }}
+	</li>
+	{% end %}
+</ul>
+{% end %}
+<!-- ========= PICKME ITEMS =========== -->
+<h3 class="status-header" section="pickme">Pick me, pick me! <span class="item-count"></span>
+	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
+<ul id="pickme-items" class="push-items push-items-section">
+	{% for request in sorted(push_contents.get('pickme', []), key=lambda x: x['created']) %}
+	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True, show_ago=True) }}
+	</li>
+	{% end %}
+</ul>
+<!-- ========= REQUESTED ITEMS  ========== -->
+<h3 class="status-header" section="requested">Open Requests <span class="item-count"></span>
+	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
+<ul id="requested-items" class="push-items push-items-section">
+<p class="smalltext">Beginning with the oldest requests:</p>
+	{% for request in sorted(available_requests, key=lambda x: x['created']) %}
+	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True, show_ago=True) }}
+	</li>
+	{% end %}
+</ul>
+{% else %}
+<!-- ========= ITEMS THAT WERE INCLUDED [CLOSED PUSH] ========== -->
+<h3 class="status-header">Included Requests ({{ len(push_contents.get('all', [])) }})</h3>
+<ul id="added-items" class="push-items push-items-section">
+	{% for request in push_contents.get('all', []) %}
+	<li {% if request['user'] == current_user %}class="mine"{% end %}>
+		{{ modules.Request(request) }}
+	</li>
+	{% end %}
+</ul>
+{% end %}

--- a/templates/push.html
+++ b/templates/push.html
@@ -79,51 +79,9 @@
 		{% end %}
 	{% end %}
 </ul>
-<!-- ======== PUSH STATES ========= -->
-{% if push_info['state'] == 'accepting' %}
-{% for (section,sect_title) in [('blessed', 'Deployed to Prod'), ('verified', 'Verified on Stage'),	('staged', 'Deployed to Stage'), ('added', 'Added to Deploy Branch')] %}
-<h3 class="status-header" section="{{section}}">{{ sect_title }} <span class="item-count"></span>
-	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
-<ul id="{{ section }}-items" class="push-items push-items-section items-in-push">
-	{% for request in sorted(push_contents.get(section, []), key=lambda x: x['user']) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
-		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True) }}
-	</li>
-	{% end %}
-</ul>
-{% end %}
-<!-- ========= PICKME ITEMS =========== -->
-<h3 class="status-header" section="pickme">Pick me, pick me! <span class="item-count"></span>
-	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
-<ul id="pickme-items" class="push-items push-items-section">
-	{% for request in sorted(push_contents.get('pickme', []), key=lambda x: x['created']) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
-		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True, show_ago=True) }}
-	</li>
-	{% end %}
-</ul>
-<!-- ========= REQUESTED ITEMS  ========== -->
-<h3 class="status-header" section="requested">Open Requests <span class="item-count"></span>
-	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
-<ul id="requested-items" class="push-items push-items-section">
-<p class="smalltext">Beginning with the oldest requests:</p>
-	{% for request in sorted(available_requests, key=lambda x: x['created']) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
-		{{ modules.Request(request, pushmaster=(push_info['user'] == current_user or override), push_buttons=True, show_ago=True) }}
-	</li>
-	{% end %}
-</ul>
-{% else %}
-<!-- ========= ITEMS THAT WERE INCLUDED [CLOSED PUSH] ========== -->
-<h3 class="status-header">Included Requests ({{ len(push_contents.get('all', [])) }})</h3>
-<ul id="added-items" class="push-items push-items-section">
-	{% for request in push_contents.get('all', []) %}
-	<li {% if request['user'] == current_user %}class="mine"{% end %}>
-		{{ modules.Request(request) }}
-	</li>
-	{% end %}
-</ul>
-{% end %}
+
+{% include 'push-status.html' %}
+
 <div id="dialog-prototypes" style="display: none;">
 <!-- "Run a command" dialog -->
 	<div id="run-a-command">

--- a/templates/push.html
+++ b/templates/push.html
@@ -7,23 +7,7 @@
 	{% include 'edit-push.html' %}
 </div>
 <!-- ========= PUSH INFO ========== -->
-<ul id="push-info" class="push-info standalone" push="{{ int(push_info['id']) }}" pushmaster="{{ escape(push_info['user']) }}" branch="{{ escape(push_info['branch']) }}">
-	<li><span class="label">Pushmaster</span><span class="value">{{ escape(push_info['user']) }}</span></li>
-	<li><span class="label">Branch</span><span class="value">{{ escape(push_info['branch']) }}</span></li>
-{% if push_info['state'] == 'accepting' %}
-	<li><span class="label">Buildbot Runs</span><span class="value"><a href="http://{{ escape(Settings['buildbot']['servername']) }}/branch/{{ escape(push_info['branch']) }}">url</a></span></li>
-{% end %}
-	<li><span class="label">State</span><span class="value"><ul class="tags">
-			<li class="tag-{{ escape(push_info['state']) }}">{{ escape(push_info['state']) }}</li>
-		</ul></span></li>
-	<li><span class="label">Push Type</span><span class="value"><ul class="tags">
-			<li class="tag-{{ escape(push_info['pushtype']) }}">{{ escape(push_info['pushtype']) }}</li>
-		</ul></span></li>
-	<li><span class="label">Created</span><span class="value">{{ datetime.datetime.fromtimestamp(push_info['created']).strftime("%x %X") }}</span></li>
-{% if not push_info['created'] == push_info['modified'] %}
-	<li><span class="label">Modified</span><span class="value">{{ datetime.datetime.fromtimestamp(push_info['modified']).strftime("%x %X") }}</span></li>
-{% end %}
-</ul>
+{% include 'push-info.html' %}
 <!-- ========= BUTTON BAR ========== -->
 <ul id="action-buttons">
 	<li><button id="expand-all-requests">Expand All</button></li>

--- a/templates/push.html
+++ b/templates/push.html
@@ -13,61 +13,8 @@
 
 {% include 'push-status.html' %}
 
-<div id="dialog-prototypes" style="display: none;">
-<!-- "Run a command" dialog -->
-	<div id="run-a-command">
-		<pre id="command-to-run">&nbsp;</pre>
-		<p class="directions">
-			Wait for it to complete, then
-			<button id="command-done">Continue</button>
-		</p>
-		<p class="mininote">
-			(If it fails, click the X or press Esc.)
-		</p>
-	</div>
-<!-- "Comment on a request" dialog -->
-	<div id="comment-on-request">
-		<textarea id="comment-input-area"></textarea>
-		<p class="directions">
-			Enter your comment here, then
-			<button id="submit-request-comment">Submit</button>
-		</p>
-	</div>
-<!-- "Check in multiple requests" dialog -->
-	<div id="merge-requests">
-		<div class="command" id="merge-branches-command">&nbsp;</div>
-		<p class="dialog-note">(Triple-click above to easily select the entire command for copying.)</p>
-		<p class="directions">
-			Once the command completes, click <button id="done-merging">here</button>
-		</p>
-	</div>
-<!-- Push checklist dialog -->
-	<div id="push-checklist">
-		<h4>Before Staging</h4>
-		<ul id="checklist-before-staging">
-			<li><input type="checkbox" /> Foo</li>
-			<li><input type="checkbox" /> Foo</li>
-		</ul>
-		<h4>Before Blessing</h4>
-		<ul id="checklist-before-blessing">
-			<li><input type="checkbox" /> Foo</li>
-			<li><input type="checkbox" /> Foo</li>
-		</ul>
-		<h4>After Live</h4>
-		<ul id="checklist-after-live">
-			<li><input type="checkbox" /> Foo</li>
-			<li><input type="checkbox" /> Foo</li>
-		</ul>
-	</div>
-<!-- Messaging dialog -->
-	<div id="send-message-prompt">
-		<input id="send-message-contents" />
-		<p class="directions">
-			Enter the message you wish to send here, then
-			<button id="send-message">Send</button>
-		</p>
-	</div>
-</div>
+{% include 'push-dialogs.html' %}
+
 {% end %}
 
 {% block scripts %}

--- a/templates/push.html
+++ b/templates/push.html
@@ -4,29 +4,7 @@
 
 {% block content %}
 <div id="form-anchor">&nbsp;
-<form id="push-info-form" class="popup-form" action="/editpush" method="POST">
-<div class="form-wrapper">
-	
-	<h2>Edit Push</h2>
-
-	<label for="push-title">Title</label>
-	<input name="push-title" id="push-title" value="{{ escape(push_info['title']) }}" />
-
-	<label for="push-branch">Branch</label>
-	<input name="push-branch" id="push-branch" value="{{ escape(push_info['branch']) }}" />
-
-	<input type="hidden" name="id" value="{{ int(push_info['id']) }}" />
-
-	{% if not push_info['user'] == current_user %}
-	<p id="update-notice">Updating this push will transfer its ownership to you.</p>
-	{% end %}
-
-	<div class="buttons">
-		<input type="submit" id="push-create" name="push-submit" value="Update Push" />
-		<input type="reset" id="push-cancel" name="push-cancel" value="Cancel" />
-	</div>
-</div>
-</form>
+	{% include 'edit-push.html' %}
 </div>
 <!-- ========= PUSH INFO ========== -->
 <ul id="push-info" class="push-info standalone" push="{{ int(push_info['id']) }}" pushmaster="{{ escape(push_info['user']) }}" branch="{{ escape(push_info['branch']) }}">

--- a/templates/push.html
+++ b/templates/push.html
@@ -9,38 +9,7 @@
 <!-- ========= PUSH INFO ========== -->
 {% include 'push-info.html' %}
 <!-- ========= BUTTON BAR ========== -->
-<ul id="action-buttons">
-	<li><button id="expand-all-requests">Expand All</button></li>
-	<li><button id="collapse-all-requests">Collapse All</button></li>
-	&mdash;
-	{% if current_user in (push_info['extra_pings'] or []) %}
-	<li><button id="ping-me" action="unset">Don't Ping Me</button></li>
-	{% else %}
-	<li><button id="ping-me" action="set">Ping Me</button></li>
-	{% end %}
-	{% if push_info['user'] == current_user or override %}
-		&mdash;
-		<li><button id="edit-push">Edit Push</button></li>
-		{% if push_info['state'] == 'accepting' %}
-		<li><button id="discard-push">Discard Push</button></li>
-		&mdash;
-		<li><button id="add-selected-requests">Add Selected</button></li>
-		<li><button id="remove-selected-requests">Remove Selected</button></li>
-		<li><button id="rebuild-deploy-branch">Rebuild Deploy Branch</button></li>
-		&mdash;
-		<li><button id="deploy-to-stage">Added &rarr; Stage</button></li>
-		<li><button id="deploy-to-prod">Stage &rarr; Prod</button></li>
-		<li><button id="merge-to-master">Prod &rarr; master</button></li>
-		&mdash;
-		<li><button id="message-all">Message All</button></li>
-		<li><button id="show-checklist">Push Checklist</button></li>
-		{% end %}
-	{% else %}
-		{% if push_info['state'] == 'accepting' %}
-		&mdash; <li><button id="edit-push">Takeover Push</button></li>
-		{% end %}
-	{% end %}
-</ul>
+{% include 'push-button-bar.html' %}
 
 {% include 'push-status.html' %}
 

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -8,6 +8,7 @@ from testify.__init__ import *
 from mocksettings import MockedSettings
 from testservlet import AsyncTestCase
 from testservlet import ServletTestMixin
+from testservlet import TemplateTestCase
 from testdb import *
 
 
@@ -15,5 +16,6 @@ __all__ = [
     AsyncTestCase,
     MockedSettings,
     testify,
-    ServletTestMixin
+    ServletTestMixin,
+    TemplateTestCase
 ]

--- a/testing/testdb.py
+++ b/testing/testdb.py
@@ -40,13 +40,13 @@ class FakeDataMixin(object):
     yesterday = time.mktime((datetime.now() - timedelta(days=1)).timetuple())
 
     push_data = [
-        [10, 'OnePush', 'bmetin', 'deploy-1', 'abc', 'live', yesterday, now, 'regular', ''],
-        [11, 'TwoPush', 'troscoe', 'deploy-2', 'def', 'accepting', now, now, 'regular', ''],
-        [12, 'RedPush', 'heyjoe', 'deploy-3', 'ghi', 'accepting', now, now, 'regular', ''],
-        [13, 'BluePush', 'humpty', 'deploy-4', 'jkl', 'accepting', now, now, 'regular', ''],
+        [10, 'OnePush', 'bmetin', 'deploy-1', '', 'abc', 'live', yesterday, now, 'regular', ''],
+        [11, 'TwoPush', 'troscoe', 'deploy-2', '', 'def', 'accepting', now, now, 'regular', ''],
+        [12, 'RedPush', 'heyjoe', 'deploy-3', '', 'ghi', 'accepting', now, now, 'regular', ''],
+        [13, 'BluePush', 'humpty', 'deploy-4', '', 'jkl', 'accepting', now, now, 'regular', ''],
     ]
     push_keys = [
-        'id', 'title', 'user', 'branch', 'revision', 'state',
+        'id', 'title', 'user', 'branch', 'stageenv', 'revision', 'state',
         'created', 'modified', 'pushtype', 'extra_pings'
     ]
 

--- a/testing/testdb.sql
+++ b/testing/testdb.sql
@@ -15,6 +15,7 @@ CREATE TABLE push_pushes (
 	modified INTEGER,
 	pushtype VARCHAR,
 	extra_pings VARCHAR,
+	stageenv VARCHAR,
 	PRIMARY KEY (id)
 );
 INSERT INTO "push_pushes" VALUES(
@@ -27,6 +28,7 @@ INSERT INTO "push_pushes" VALUES(
        1346458516.87736,
        1346458516.87736,
        'regular',
+       NULL,
        NULL
 );
 INSERT INTO "push_pushes" VALUES(2,
@@ -38,6 +40,7 @@ INSERT INTO "push_pushes" VALUES(2,
        1346458663.2721,
        1346458663.2721,
        'private',
+       NULL,
        NULL
 );
 CREATE TABLE push_pushcontents (

--- a/testing/testservlet.py
+++ b/testing/testservlet.py
@@ -1,15 +1,18 @@
 import logging
 import os
+import types
 
 import mock
 import tornado.web
 from lxml import etree
 from tornado.testing import AsyncHTTPTestCase
+from tornado.web import UIModule
 
 from core import db
 from core.requesthandler import RequestHandler
 from testify.utils import turtle
 import ui_modules
+import ui_methods
 import testing as T
 
 FORMAT = "%(asctime)-15s %(message)s"
@@ -35,6 +38,7 @@ class AsyncTestCase(AsyncHTTPTestCase):
             template_path = os.path.join(os.path.dirname(__file__), "../templates"),
             cookie_secret = 'cookie_secret',
             ui_modules = ui_modules,
+            ui_methods = ui_methods,
             autoescape = None,
         )
         return app
@@ -52,7 +56,14 @@ class TemplateTestCase(T.TestCase):
         application.settings = {
             'static_path': os.path.join(os.path.dirname(__file__), "../static"),
             'template_path': os.path.join(os.path.dirname(__file__), "../templates"),
+            'autoescape': None,
         }
+
+        application.ui_modules = {}
+        application.ui_methods = {}
+        self._load_ui_modules(application, ui_modules)
+        self._load_ui_methods(application, ui_methods)
+
         if self.authenticated:
             application.settings['cookie_secret'] = 'cookie_secret'
         request = turtle.Turtle()
@@ -63,6 +74,38 @@ class TemplateTestCase(T.TestCase):
         rendered_page = ''.join(self.servlet._write_buffer)
         tree = etree.HTML(rendered_page)
         return tree
+
+    # The following methods are lifted from tornado.web.Application
+    def _load_ui_methods(self, application, methods):
+        if type(methods) is types.ModuleType:
+            self._load_ui_methods(
+                    application,
+                    dict((n, getattr(methods, n)) for n in dir(methods)))
+        elif isinstance(methods, list):
+            for m in methods:
+                self._load_ui_methods(m)
+        else:
+            for name, fn in methods.iteritems():
+                if not name.startswith("_") and hasattr(fn, "__call__") \
+                   and name[0].lower() == name[0]:
+                    application.ui_methods[name] = fn
+
+    def _load_ui_modules(self, application, modules):
+        if type(modules) is types.ModuleType:
+            self._load_ui_modules(
+                    application,
+                    dict((n, getattr(modules, n)) for n in dir(modules)))
+        elif isinstance(modules, list):
+            for m in modules:
+                self._load_ui_modules(m)
+        else:
+            assert isinstance(modules, dict)
+            for name, cls in modules.iteritems():
+                try:
+                    if issubclass(cls, UIModule):
+                        application.ui_modules[name] = cls
+                except TypeError:
+                    pass
 
 
 class ServletTestMixin(AsyncTestCase):

--- a/testing/testservlet.py
+++ b/testing/testservlet.py
@@ -3,9 +3,12 @@ import os
 
 import mock
 import tornado.web
+from lxml import etree
 from tornado.testing import AsyncHTTPTestCase
 
 from core import db
+from core.requesthandler import RequestHandler
+from testify.utils import turtle
 import ui_modules
 import testing as T
 
@@ -35,6 +38,31 @@ class AsyncTestCase(AsyncHTTPTestCase):
             autoescape = None,
         )
         return app
+
+
+class TemplateTestCase(T.TestCase):
+    """Bare minimum setup to render and test templates"""
+    __test__ = False
+
+    authenticated = False
+
+    @T.setup
+    def setup_servlet(self):
+        application = turtle.Turtle()
+        application.settings = {
+            'static_path': os.path.join(os.path.dirname(__file__), "../static"),
+            'template_path': os.path.join(os.path.dirname(__file__), "../templates"),
+        }
+        if self.authenticated:
+            application.settings['cookie_secret'] = 'cookie_secret'
+        request = turtle.Turtle()
+        self.servlet = RequestHandler(application, request)
+
+    def render_etree(self, page, *args, **kwargs):
+        self.servlet.render(page, *args, **kwargs)
+        rendered_page = ''.join(self.servlet._write_buffer)
+        tree = etree.HTML(rendered_page)
+        return tree
 
 
 class ServletTestMixin(AsyncTestCase):

--- a/tests/test_servlet_editpush.py
+++ b/tests/test_servlet_editpush.py
@@ -33,6 +33,7 @@ class EditPushServletTest(T.TestCase, T.ServletTestMixin, T.FakeDataMixin):
             'id':  existing_push[0],
             'push-title': 'clever-title',
             'push-branch': 'deploy-clever-branch',
+            'push-stageenv': 'stagea',
             }
 
         response = self.fetch(
@@ -52,3 +53,4 @@ class EditPushServletTest(T.TestCase, T.ServletTestMixin, T.FakeDataMixin):
         T.assert_equal(existing_push[1], push['push-title'])
         T.assert_equal(existing_push[2], 'testuser')
         T.assert_equal(existing_push[3], push['push-branch'])
+        T.assert_equal(existing_push[10], push['push-stageenv'])

--- a/tests/test_servlet_editpush.py
+++ b/tests/test_servlet_editpush.py
@@ -1,0 +1,54 @@
+from mock import patch
+import urllib
+
+from core import db
+from core.util import get_servlet_urlspec
+from servlets.editpush import EditPushServlet
+import testing as T
+
+
+class EditPushServletTest(T.TestCase, T.ServletTestMixin, T.FakeDataMixin):
+
+    def get_handlers(self):
+        return [get_servlet_urlspec(EditPushServlet)]
+
+    @patch.dict(db.Settings, T.MockedSettings)
+    @patch.object(EditPushServlet, 'redirect')
+    @patch.object(EditPushServlet, 'get_current_user', return_value='testuser')
+    def test_editpush(self, *_):
+        results = []
+
+        def on_db_return(success, db_results):
+            assert success
+            results.extend(db_results.fetchall())
+
+        results = []
+        db.execute_cb(db.push_pushes.select(), on_db_return)
+        num_results_before = len(results)
+
+        existing_push = self.get_pushes()[0]
+        print existing_push
+
+        push = {
+            'id':  existing_push[0],
+            'push-title': 'clever-title',
+            'push-branch': 'deploy-clever-branch',
+            }
+
+        response = self.fetch(
+            '/editpush',
+            method='POST',
+            body=urllib.urlencode(push)
+        )
+        T.assert_equal(response.error, None)
+
+        results = []
+        db.execute_cb(db.push_pushes.select(), on_db_return)
+        num_results_after = len(results)
+
+        T.assert_equal(num_results_after, num_results_before)
+
+        existing_push = self.get_pushes()[0]
+        T.assert_equal(existing_push[1], push['push-title'])
+        T.assert_equal(existing_push[2], 'testuser')
+        T.assert_equal(existing_push[3], push['push-branch'])

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -1,0 +1,64 @@
+import time
+
+import testing as T
+
+class PushTemplateTest(T.TemplateTestCase):
+
+    authenticated = True
+    push_page = 'push.html'
+
+    accepting_push_sections = ['blessed', 'verified', 'staged', 'added', 'pickme', 'requested']
+
+    basic_push = {
+            'id': 0,
+            'user': 'pushmaster',
+            'title': 'fake_push',
+            'branch': 'deploy-fake-branch',
+            'state': 'accepting',
+            'pushtype': 'Normal',
+            'created': 23423423,
+            'modified': 2342432423,
+            'extra_pings': None,
+        }
+
+    basic_kwargs = {
+            'page_title': 'fake_push_title',
+            'push_contents': {},
+            'available_requests': [],
+            'fullrepo': 'not/a/repo',
+            'override': False
+            }
+
+    def test_include_push_status_when_accepting(self):
+        tree = self.render_etree(
+            self.push_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+
+        found_h3 = []
+        for h3 in tree.iter('h3'):
+            T.assert_equal('status-header', h3.attrib['class'])
+            T.assert_in(h3.attrib['section'], self.accepting_push_sections)
+            found_h3.append(h3)
+
+        T.assert_equal(len(self.accepting_push_sections), len(found_h3))
+
+    def test_include_push_status_when_done(self):
+        push = dict(self.basic_push)
+        push['state'] = 'live'
+
+        tree = self.render_etree(
+            self.push_page,
+            push_info=push,
+            **self.basic_kwargs)
+
+        found_h3 = []
+        for h3 in tree.iter('h3'):
+            T.assert_equal('status-header', h3.attrib['class'])
+            found_h3.append(h3)
+
+        T.assert_equal(1, len(found_h3))
+
+
+if __name__ == '__main__':
+    T.run()

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -10,6 +10,7 @@ class PushTemplateTest(T.TemplateTestCase):
     edit_push_page = 'edit-push.html'
     push_info_page = 'push-info.html'
     push_button_bar_page = 'push-button-bar.html'
+    push_dialogs_page = 'push-dialogs.html'
 
     accepting_push_sections = ['blessed', 'verified', 'staged', 'added', 'pickme', 'requested']
     now = time.time()
@@ -129,6 +130,19 @@ class PushTemplateTest(T.TemplateTestCase):
                 found_form.append(form)
 
         T.assert_equal(len(found_form), 1)
+
+    def test_include_dialogs(self):
+        tree = self.render_etree(
+            self.push_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+
+        found_divs = []
+        for div in tree.iter('div'):
+            if 'id' in div.attrib and div.attrib['id'] ==  'dialog-prototypes':
+                found_divs.append(div)
+
+        T.assert_equal(len(found_divs), 1)
 
 
     def test_edit_push_fields(self):
@@ -251,6 +265,25 @@ class PushTemplateTest(T.TemplateTestCase):
         T.assert_equal(
                 len(found_buttons),
                 len(self.push_button_ids_base + self.push_button_ids_pushmaster))
+
+    dialog_ids = [
+            'dialog-prototypes',
+            'run-a-command', 'comment-on-request', 'merge-requests',
+            'merge-branches-command', 'push-checklist', 'send-message-prompt'
+    ]
+
+    def test_dialogs_divs(self):
+        tree = self.render_etree(
+            self.push_dialogs_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+
+        found_divs = []
+        for div in tree.iter('div'):
+            T.assert_in(div.attrib['id'], self.dialog_ids)
+            found_divs.append(div)
+
+        T.assert_equal(len(found_divs),len(self.dialog_ids))
 
 
 if __name__ == '__main__':

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -8,6 +8,7 @@ class PushTemplateTest(T.TemplateTestCase):
     push_page = 'push.html'
 
     accepting_push_sections = ['blessed', 'verified', 'staged', 'added', 'pickme', 'requested']
+    now = time.time()
 
     basic_push = {
             'id': 0,
@@ -15,9 +16,9 @@ class PushTemplateTest(T.TemplateTestCase):
             'title': 'fake_push',
             'branch': 'deploy-fake-branch',
             'state': 'accepting',
-            'pushtype': 'Normal',
-            'created': 23423423,
-            'modified': 2342432423,
+            'pushtype': 'Regular',
+            'created': now,
+            'modified': now,
             'extra_pings': None,
         }
 
@@ -28,6 +29,24 @@ class PushTemplateTest(T.TemplateTestCase):
             'fullrepo': 'not/a/repo',
             'override': False
             }
+
+    basic_request = {
+            'id': 0,
+            'repo': 'non-existent',
+            'branch': 'non-existent',
+            'user': 'testuser',
+            'reviewid': 0,
+            'title': 'some title',
+            'tags': None,
+            'revision': '0' * 40,
+            'state': 'requested',
+            'created': now,
+            'modified': now,
+            'description': 'nondescript',
+            'comments': 'nocomment',
+            'watchers': None,
+            }
+
 
     def test_include_push_status_when_accepting(self):
         tree = self.render_etree(
@@ -59,6 +78,18 @@ class PushTemplateTest(T.TemplateTestCase):
 
         T.assert_equal(1, len(found_h3))
 
+    def test_include_edit_push(self):
+        tree = self.render_etree(
+            self.push_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+
+        found_form = []
+        for form in tree.iter('form'):
+            if form.attrib['id'] ==  'push-info-form':
+                found_form.append(form)
+
+        T.assert_equal(len(found_form), 1)
 
 if __name__ == '__main__':
     T.run()

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -6,6 +6,7 @@ class PushTemplateTest(T.TemplateTestCase):
 
     authenticated = True
     push_page = 'push.html'
+    edit_push_page = 'edit-push.html'
 
     accepting_push_sections = ['blessed', 'verified', 'staged', 'added', 'pickme', 'requested']
     now = time.time()
@@ -15,6 +16,7 @@ class PushTemplateTest(T.TemplateTestCase):
             'user': 'pushmaster',
             'title': 'fake_push',
             'branch': 'deploy-fake-branch',
+            'stageenv': '',
             'state': 'accepting',
             'pushtype': 'Regular',
             'created': now,
@@ -90,6 +92,30 @@ class PushTemplateTest(T.TemplateTestCase):
                 found_form.append(form)
 
         T.assert_equal(len(found_form), 1)
+
+
+    def test_edit_push_fields(self):
+        tree = self.render_etree(
+            self.edit_push_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+        labels = ['push-title', 'push-branch', 'push-stageenv']
+        inputs = ['push-title', 'push-branch', 'push-stageenv', 'id' ,'push-submit', 'push-cancel']
+
+        found_labels = []
+        for label in tree.iter('label'):
+            T.assert_in(label.attrib['for'], labels)
+            found_labels.append(label)
+
+        T.assert_equal(len(found_labels), len(labels))
+
+        found_inputs = []
+        for input in tree.iter('input'):
+            T.assert_in(input.attrib['name'], inputs)
+            found_inputs.append(input)
+
+        T.assert_equal(len(found_inputs), len(inputs))
+
 
 if __name__ == '__main__':
     T.run()

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -243,7 +243,7 @@ class PushTemplateTest(T.TemplateTestCase):
     push_button_ids_pushmaster = [
             'discard-push', 'add-selected-requests',
             'remove-selected-requests', 'rebuild-deploy-branch',
-            'deploy-to-stage', 'deploy-to-prod', 'merge-to-master',
+            'deploy-to-stage-step0', 'deploy-to-prod', 'merge-to-master',
             'message-all', 'show-checklist']
 
     def test_push_buttons_random_user(self):
@@ -282,7 +282,8 @@ class PushTemplateTest(T.TemplateTestCase):
     dialog_ids = [
             'dialog-prototypes',
             'run-a-command', 'comment-on-request', 'merge-requests',
-            'merge-branches-command', 'push-checklist', 'send-message-prompt'
+            'merge-branches-command', 'push-checklist', 'send-message-prompt',
+            'set-stageenv-prompt'
     ]
 
     def test_dialogs_divs(self):

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -226,6 +226,19 @@ class PushTemplateTest(T.TemplateTestCase):
 
         self.assert_push_info_list(list(tree.iter('ul'))[0], push_info_items)
 
+    def test_push_info_list_items_stageenv(self):
+        push = dict(self.basic_push)
+        push['stageenv'] = 'stageenv'
+        tree = self.render_etree(
+            self.push_info_page,
+            push_info=push,
+            **self.basic_kwargs)
+
+        push_info_items = dict(self.basic_push_info_items)
+        push_info_items['Stage'] = 'stageenv'
+
+        self.assert_push_info_list(list(tree.iter('ul'))[0], push_info_items)
+
     push_button_ids_base = ['expand-all-requests', 'collapse-all-requests', 'ping-me', 'edit-push']
     push_button_ids_pushmaster = [
             'discard-push', 'add-selected-requests',

--- a/tests/test_template_pushes.py
+++ b/tests/test_template_pushes.py
@@ -1,0 +1,29 @@
+import testing as T
+
+class PushesTemplateTest(T.TemplateTestCase):
+
+    authenticated = True
+    pushes_page = 'pushes.html'
+    new_push_page = 'new-push.html'
+
+    def render_pushes_page(self, page_title='Pushes', pushes=[], pushes_per_page=50, last_push=None):
+        return self.render_etree(self.pushes_page,
+            page_title=page_title,
+            pushes=pushes,
+            rpp=pushes_per_page,
+            last_push=last_push
+        )
+
+    def test_include_new_push(self):
+        tree = self.render_pushes_page()
+
+        found_form = []
+        for form in tree.iter('form'):
+            if form.attrib['id'] == 'push-info-form':
+                found_form.append(form)
+
+        T.assert_equal(len(found_form), 1)
+
+
+if __name__ == '__main__':
+    T.run()

--- a/tests/test_ui_methods.py
+++ b/tests/test_ui_methods.py
@@ -1,0 +1,25 @@
+import testing as T
+
+from ui_methods import authorized_to_manage_request
+
+class UIMethodTest(T.TestCase):
+
+    def test_authorized_to_manage_request_random_user(self):
+        request = {'user': 'testuser', 'watchers': None }
+        T.assert_equal(False, authorized_to_manage_request(None, request, 'notme'))
+
+    def test_authorized_to_manage_request_request_user(self):
+        request = {'user': 'testuser', 'watchers': None }
+        T.assert_equal(True, authorized_to_manage_request(None, request, 'testuser'))
+
+    def test_authorized_to_manage_request_pushmaster(self):
+        request = {'user': 'testuser', 'watchers': None }
+        T.assert_equal(True, authorized_to_manage_request(None, request, 'notme', True))
+
+    def test_authorized_to_manage_request_watcher(self):
+        request = {'user': 'testuser', 'watchers': 'watcher1' }
+        T.assert_equal(True, authorized_to_manage_request(None, request, 'watcher1'))
+
+
+if __name__ == '__main__':
+    T.run()

--- a/ui_methods.py
+++ b/ui_methods.py
@@ -1,0 +1,6 @@
+def authorized_to_manage_request(_, request, current_user, pushmaster=False):
+    if pushmaster or \
+       request['user'] == current_user or \
+       (request['watchers'] and current_user in request['watchers'].split(',')):
+        return True
+    return False


### PR DESCRIPTION
The emails that go out to participants when their requests are deployed to stage are stage environment agnostic.

Make them aware of the stage environment so that participants don't need to go back to pushmanager to check.

This requires:
0) pushmaster needs the ability to specify the stage environment
1) All views should be updated to reflect stage environment
2) Emails need to reflect stage environment
