### PR TITLE
Don't render an extra \n for request descriptions

### DIFF
--- a/static/js/modules/request.js
+++ b/static/js/modules/request.js
@@ -15,7 +15,7 @@ $(function() {
         data = data.replace(/"/g, '&quot;');
 
         // Newlines -> Rendered newlines
-        data = data.replace(/\n/g, '\n<br>\n');
+        data = data.replace(/\n/g, '\n<br>');
 
         // Bold comment headers
         data = data.replace(/Comment from \w+:/g, function(m) { return '<strong>' + m + '</strong>'; });


### PR DESCRIPTION
Fixes issue Yelp/pushmanager#28

Can't test without a javascript testing framework. 

`request.js` replaces the added the `<br>` formatting while `newrequest.js`  just takes the non-html text. Thus, `request.js` shouldn't be adding a `\n`.
