### PR TITLE
Request takeover checkbox

### DIFF
--- a/static/css/modules/newrequest.css
+++ b/static/css/modules/newrequest.css
@@ -41,6 +41,6 @@
 	margin-top: 10px;
 }
 
-#request-info-form #request-not-yours-notice {
+#request-info-form #request-form-takeover {
 	float: left;
 }

--- a/static/js/modules/newrequest.js
+++ b/static/js/modules/newrequest.js
@@ -34,7 +34,7 @@ $(function() {
     };
     $('#request-info-form').submit(PushManager.NewRequestDialog.validate);
 
-    PushManager.NewRequestDialog.open_new_request = function(title, branch, repo, review, comments, description, watchers, tags, requestid, notyours) {
+    PushManager.NewRequestDialog.open_new_request = function(title, branch, repo, review, comments, description, watchers, tags, requestid, requestuser, notyours) {
         var d = PushManager.NewRequestDialog.element;
 
         d.find('#request-form-title').val(title || '');
@@ -45,8 +45,9 @@ $(function() {
         d.find('#request-form-comments').val(comments || '');
         d.find('#request-form-description').val(description || '');
         d.find('#request-form-watchers').val(watchers || '');
+        d.find('#request-form-user').val(requestuser || '');
         d.find('#request-form-id').val(requestid || '');
-        d.find('#request-not-yours-notice').toggle(notyours || false);
+        d.find('#request-form-takeover').toggle(notyours || false);
 
         d.dialog('open');
     };
@@ -72,6 +73,7 @@ $(function() {
             that.attr('watchers'),
             tags,
             that.attr('request'),
+            that.attr('user'),
             that.attr('user') != PushManager.current_user
         );
     });

--- a/templates/modules/newrequest.html
+++ b/templates/modules/newrequest.html
@@ -45,9 +45,10 @@
 	<label for="request-form-watchers">Additional Watchers (comma separated)</label>
 	<input name="request-watchers" id="request-form-watchers" />
 
-	<input type="hidden" name="request-id" id="request-form-id" value="" />
+	<label for="request-form-takeover"><input type="checkbox" name="request-takeover" id="request-form-takeover" style="display: inline; width: 5%" />
+		This request is not yours. Check to take ownership.</label>
 
-	<p id="request-not-yours-notice">Updating this request will transfer its ownership to you.</p>
+	<input type="hidden" name="request-id" id="request-form-id" value="" />
 
 	<input type="submit" id="request-form-submit" name="request-submit" value="Submit Request" />
 </fieldset>

--- a/templates/modules/newrequest.html
+++ b/templates/modules/newrequest.html
@@ -45,9 +45,12 @@
 	<label for="request-form-watchers">Additional Watchers (comma separated)</label>
 	<input name="request-watchers" id="request-form-watchers" />
 
-	<label for="request-form-takeover"><input type="checkbox" name="request-takeover" id="request-form-takeover" style="display: inline; width: 5%" />
-		This request is not yours. Check to take ownership.</label>
+	<label for="request-form-takeover">
+		<input type="checkbox" name="request-takeover" id="request-form-takeover" value="takeover" style="display: inline; width: 5%" />
+		This request is not yours. Check to take ownership.
+	</label>
 
+	<input type="hidden" name="request-user" id="request-form-user" value="" />
 	<input type="hidden" name="request-id" id="request-form-id" value="" />
 
 	<input type="submit" id="request-form-submit" name="request-submit" value="Submit Request" />

--- a/tests/test_template_newrequest.py
+++ b/tests/test_template_newrequest.py
@@ -5,7 +5,7 @@ class NewRequestTemplateTest(T.TemplateTestCase):
     authenticated = True
     newrequest_page = 'modules/newrequest.html'
 
-    form_elements = ['title', 'tags', 'review', 'repo', 'branch', 'description', 'comments', 'watchers']
+    form_elements = ['title', 'tags', 'review', 'repo', 'branch', 'description', 'comments', 'watchers', 'takeover']
 
     def test_request_form_labels(self):
         tree = self.render_etree(self.newrequest_page)
@@ -27,7 +27,7 @@ class NewRequestTemplateTest(T.TemplateTestCase):
         found_id = []
         found_name = []
         for field in tree.iter('input'):
-            if 'type' not in field.attrib:  # ignore hidden/submit
+            if 'type' not in field.attrib or field.attrib['type'] in ['checkbox']:  # ignore hidden/submit
                 found_id.append(field.attrib['id'])
                 found_name.append(field.attrib['name'])
 


### PR DESCRIPTION
Not all request edits are meant to takeover request. Make this explicit with a checkbox.
