### PR TITLE
Hide self takeover

### DIFF
--- a/static/js/modules/newrequest.js
+++ b/static/js/modules/newrequest.js
@@ -47,7 +47,7 @@ $(function() {
         d.find('#request-form-watchers').val(watchers || '');
         d.find('#request-form-user').val(requestuser || '');
         d.find('#request-form-id').val(requestid || '');
-        d.find('#request-form-takeover').toggle(notyours || false);
+        d.find('#request-form-takeover-label').toggle(notyours || false);
 
         d.dialog('open');
     };

--- a/templates/modules/newrequest.html
+++ b/templates/modules/newrequest.html
@@ -45,7 +45,7 @@
 	<label for="request-form-watchers">Additional Watchers (comma separated)</label>
 	<input name="request-watchers" id="request-form-watchers" />
 
-	<label for="request-form-takeover">
+	<label for="request-form-takeover" id="request-form-takeover-label">
 		<input type="checkbox" name="request-takeover" id="request-form-takeover" value="takeover" style="display: inline; width: 5%" />
 		This request is not yours. Check to take ownership.
 	</label>

--- a/tests/test_template_newrequest.py
+++ b/tests/test_template_newrequest.py
@@ -11,10 +11,13 @@ class NewRequestTemplateTest(T.TemplateTestCase):
         tree = self.render_etree(self.newrequest_page)
 
         form_attr = ['request-form-%s' % elem for elem in self.form_elements]
+        form_attr_with_id = ['takeover']
 
         found_labels = []
         for label in tree.iter('label'):
             found_labels.append(label.attrib['for'])
+            if label.attrib['for'] in form_attr_with_id:
+                T.assert_equal(label.attrib['id'], '%s-label' % label.attrib['for'])
 
         T.assert_sorted_equal(form_attr, found_labels)
 


### PR DESCRIPTION
The label+checkbox for takeover should be hidden, not just the checkbox.

No javascript tests yet.
