### PR TITLE
New Request no longer auto-closes when pressing esc.

### DIFF
--- a/static/js/modules/newrequest.js
+++ b/static/js/modules/newrequest.js
@@ -10,7 +10,8 @@ $(function() {
         minWidth: 650,
         height: 805,
         maxHeight: 805,
-        minHeight: 805
+        minHeight: 805,
+        closeOnEscape: false
     });
 
     PushManager.NewRequestDialog.validate = function() {


### PR DESCRIPTION
Maybe it's just me but I instinctively use <kbd>esc</kbd> to cancel auto-complete dialogs on input boxes -- this leads to the new push request dialog auto-closing (I've done this more times than I care to admit).  This removes that behavior by setting `jquery.ui.dialog.closeOnEscape` to `false` for the new request dialog.
