### PR TITLE
Update gitignore for coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 app.*.log
 app.*.pid
 /config.yaml
+.coverage
+coverage*


### PR DESCRIPTION
We don't need these files produced by `make coverage`.
