### PR TITLE
Drop privileges before starting other services

### DIFF
--- a/core/application.py
+++ b/core/application.py
@@ -62,12 +62,12 @@ class Application:
         with daemon_context:
             pid.write(self.pid_file)
             try:
-                self.start_services()
-                pid.write(self.pid_file, append=True)
-
                 # Drop privileges
                 uid = pwd.getpwnam(Settings.get("username", "www-data"))[2]
                 os.setuid(uid)
+
+                self.start_services()
+                pid.write(self.pid_file, append=True)
 
                 tornado.ioloop.IOLoop.instance().start()
             finally:


### PR DESCRIPTION
pidfile is mode 666 so it's safe to drop privileges

Fixes #11
