### PR TITLE
Use classname of tags for edit request

### DIFF
--- a/static/js/modules/newrequest.js
+++ b/static/js/modules/newrequest.js
@@ -60,9 +60,9 @@ $(function() {
     $('.edit-request').click(function() {
         var that = $(this).closest('.request-module');
         var tags = '';
-        that.find('ul.tags > li').each(function() {
+        that.find('ul.tags > li').each(function(_, elem) {
             if(tags !== '') tags += ' ';
-            tags += $(this).text().replace(/^\s+|\s+$/g, '');
+            tags += elem.classList[0].replace(/tag-/, '');
         });
         PushManager.NewRequestDialog.open_new_request(
             that.attr('request_title'),


### PR DESCRIPTION
We have asynchronous tasks such as javascript that edits the tags on the page. The edit-button should not use these updated values when defaulting the tags list in the form.

The classname of the li corresponds to the original tag name.
