### PR TITLE
Explicit stage environment

### DIFF
--- a/UPDATING
+++ b/UPDATING
@@ -1,3 +1,14 @@
+2013.10.39
+  AFFECTS: Users with existing installs before commit UPDATEME
+  AUTHOR: milki
+
+  As of commit UPDATEME, a new column 'stageenv' has been added to the
+  'pull_pushes' table. Existing installs will 500 error until the
+  database has been updated.
+
+  A convenience script, 'pushplans/add_stageenv.sql' has been included
+  to facilitate the database update.
+
 2013.07.29
   AFFECTS: Users with existing installs before commit b3f8fa5
   AUTHOR: milki

--- a/core/db.py
+++ b/core/db.py
@@ -62,6 +62,7 @@ class PushPushes(Base):
     modified = Column(Integer, nullable=True)
     pushtype = Column(String)
     extra_pings = Column(String)
+    stageenv = Column(String, nullable=True)
 
 
 class PushRemovals(Base):

--- a/core/util.py
+++ b/core/util.py
@@ -173,6 +173,7 @@ def push_to_jsonable(push):
             'title',
             'user',
             'branch',
+            'stageenv',
             'state',
             'created',
             'modified',

--- a/pushplans/add_stageenv.sql
+++ b/pushplans/add_stageenv.sql
@@ -1,0 +1,22 @@
+/*
+Add stagenv column to pushes
+*/
+
+# MySQL Syntax
+ALTER TABLE `push_pushes`
+  ADD COLUMN `stageenv` text default NULL AFTER `extra_pings`;
+
+/* ROLLBACK COMMANDS
+
+ALTER TABLE `push_pushes``
+  DROP COLUMN `stageenv`;
+
+*/
+
+# Sqlite3 Syntax
+# WARNING: BACKUP DATABASE FIRST!
+# sqlite3 has no rollback equivalent for add column
+/*
+ALTER TABLE 'push_pushes'
+  ADD COLUMN 'stageenv' VARCHAR;
+*/

--- a/servlets/editpush.py
+++ b/servlets/editpush.py
@@ -17,6 +17,7 @@ class EditPushServlet(RequestHandler):
             'title': self._arg('push-title'),
             'user': self.current_user,
             'branch': self._arg('push-branch'),
+            'stageenv': self._arg('push-stageenv'),
             'revision': "0"*40,
             'modified': time.time(),
             })

--- a/servlets/push.py
+++ b/servlets/push.py
@@ -28,8 +28,8 @@ class PushServlet(RequestHandler):
 
         push_info, push_requests, available_requests = self.get_api_results(response)
 
-        if push_info['stageenv'] is None:
-            push_info['stageenv'] = 'Stage'
+        if not push_info['stageenv']:
+            push_info['stageenv'] = '(to be determined)'
 
         push_survey_url = Settings.get('push_survey_url', None)
 

--- a/servlets/push.py
+++ b/servlets/push.py
@@ -28,6 +28,9 @@ class PushServlet(RequestHandler):
 
         push_info, push_requests, available_requests = self.get_api_results(response)
 
+        if push_info['stageenv'] is None:
+            push_info['stageenv'] = 'Stage'
+
         push_survey_url = Settings.get('push_survey_url', None)
 
         self.render(

--- a/static/js/push.js
+++ b/static/js/push.js
@@ -440,7 +440,7 @@ $(function() {
             alert("There are staged requests which have not been verified. You must either verify or remove them.");
             return false;
         }
-        PushManager.run_command_dialog("deploy-prod --source <stagename> <deploytag>", function() {
+        PushManager.run_command_dialog("deploy-prod --source " + $('#push-info').attr('stageenv') + " <deploytag>", function() {
             // "Cancel" button was not pressed, so mark as blessed to prod
             $.ajax({
                 'type': 'POST',

--- a/templates/edit-push.html
+++ b/templates/edit-push.html
@@ -1,0 +1,23 @@
+<form id="push-info-form" class="popup-form" action="/editpush" method="POST">
+<div class="form-wrapper">
+
+	<h2>Edit Push</h2>
+
+	<label for="push-title">Title</label>
+	<input name="push-title" id="push-title" value="{{ escape(push_info['title']) }}" />
+
+	<label for="push-branch">Branch</label>
+	<input name="push-branch" id="push-branch" value="{{ escape(push_info['branch']) }}" />
+
+	<input type="hidden" name="id" value="{{ int(push_info['id']) }}" />
+
+	{% if not push_info['user'] == current_user %}
+	<p id="update-notice">Updating this push will transfer its ownership to you.</p>
+	{% end %}
+
+	<div class="buttons">
+		<input type="submit" id="push-create" name="push-submit" value="Update Push" />
+		<input type="reset" id="push-cancel" name="push-cancel" value="Cancel" />
+	</div>
+</div>
+</form>

--- a/templates/new-push.html
+++ b/templates/new-push.html
@@ -1,0 +1,25 @@
+<form id="push-info-form" class="popup-form" action="/newpush" method="POST">
+<div class="form-wrapper">
+
+	<h2>New Push</h2>
+
+	<label for="push-title">Title</label>
+	<input name="push-title" id="push-title" />
+
+	<label for="push-branch">Branch</label>
+	<input name="push-branch" id="push-branch" value="deploy-branch-with-descriptive-name" />
+
+	<label for="push-type">Push Type</label>
+	<select name="push-type" id="push-type">
+		<option selected="selected" value="regular">Regular</option>
+		<option value="urgent">Urgent (P0-only)</option>
+		<option value="morning">Morning (Use 'Regular' if it's already morning)</option>
+		<option value="private">Private (By invitation only)</option>
+	</select>
+
+	<div class="buttons">
+		<input type="submit" id="push-create" name="push-submit" value="Create Push" />
+		<input type="reset" id="push-cancel" name="push-cancel" value="Cancel" />
+	</div>
+</div>
+</form>

--- a/templates/push-button-bar.html
+++ b/templates/push-button-bar.html
@@ -1,0 +1,33 @@
+<ul id="action-buttons">
+	<li><button id="expand-all-requests">Expand All</button></li>
+	<li><button id="collapse-all-requests">Collapse All</button></li>
+	&mdash;
+	{% if current_user in (push_info['extra_pings'] or []) %}
+	<li><button id="ping-me" action="unset">Don't Ping Me</button></li>
+	{% else %}
+	<li><button id="ping-me" action="set">Ping Me</button></li>
+	{% end %}
+	{% if push_info['user'] == current_user or override %}
+		&mdash;
+		<li><button id="edit-push">Edit Push</button></li>
+		{% if push_info['state'] == 'accepting' %}
+		<li><button id="discard-push">Discard Push</button></li>
+		&mdash;
+		<li><button id="add-selected-requests">Add Selected</button></li>
+		<li><button id="remove-selected-requests">Remove Selected</button></li>
+		<li><button id="rebuild-deploy-branch">Rebuild Deploy Branch</button></li>
+		&mdash;
+		<li><button id="deploy-to-stage-step0">Added &rarr; Stage</button></li>
+		<li><button id="deploy-to-prod">Stage &rarr; Prod</button></li>
+		<li><button id="merge-to-master">Prod &rarr; master</button></li>
+		&mdash;
+		<li><button id="message-all">Message All</button></li>
+		<li><button id="show-checklist">Push Checklist</button></li>
+		{% end %}
+	{% else %}
+		{% if push_info['state'] == 'accepting' %}
+		&mdash; <li><button id="edit-push">Takeover Push</button></li>
+		{% end %}
+	{% end %}
+	<li style="display: none;">{{ modules.NewRequestDialog() }}</li>
+</ul>

--- a/templates/push-dialogs.html
+++ b/templates/push-dialogs.html
@@ -56,6 +56,12 @@
 	<div id="push-survey">
 		<p class="directions">
 			Please fill out this <button id="go-survey">quick survey.</button>
+<!-- Stage Environment dialog -->
+	<div id="set-stageenv-prompt">
+		<input id="set-stageenv-contents" />
+		<p class="directions">
+			Enter the stage environment for this push, then
+			<button id="set-stageenv">Continue</button>
 		</p>
 	</div>
 </div>

--- a/templates/push-dialogs.html
+++ b/templates/push-dialogs.html
@@ -1,0 +1,61 @@
+<div id="dialog-prototypes" style="display: none;">
+<!-- "Run a command" dialog -->
+	<div id="run-a-command">
+		<pre id="command-to-run">&nbsp;</pre>
+		<p class="directions">
+			Wait for it to complete, then
+			<button id="command-done">Continue</button>
+		</p>
+		<p class="mininote">
+			(If it fails, click the X or press Esc.)
+		</p>
+	</div>
+<!-- "Comment on a request" dialog -->
+	<div id="comment-on-request">
+		<textarea id="comment-input-area"></textarea>
+		<p class="directions">
+			Enter your comment here, then
+			<button id="submit-request-comment">Submit</button>
+		</p>
+	</div>
+<!-- "Check in multiple requests" dialog -->
+	<div id="merge-requests">
+		<div class="command" id="merge-branches-command">&nbsp;</div>
+		<p class="dialog-note">(Triple-click above to easily select the entire command for copying.)</p>
+		<p class="directions">
+			Once the command completes, click <button id="done-merging">here</button>
+		</p>
+	</div>
+<!-- Push checklist dialog -->
+	<div id="push-checklist">
+		<h4>Before Staging</h4>
+		<ul id="checklist-before-staging">
+			<li><input type="checkbox" /> Foo</li>
+			<li><input type="checkbox" /> Foo</li>
+		</ul>
+		<h4>Before Blessing</h4>
+		<ul id="checklist-before-blessing">
+			<li><input type="checkbox" /> Foo</li>
+			<li><input type="checkbox" /> Foo</li>
+		</ul>
+		<h4>After Live</h4>
+		<ul id="checklist-after-live">
+			<li><input type="checkbox" /> Foo</li>
+			<li><input type="checkbox" /> Foo</li>
+		</ul>
+	</div>
+<!-- Messaging dialog -->
+	<div id="send-message-prompt">
+		<input id="send-message-contents" />
+		<p class="directions">
+			Enter the message you wish to send here, then
+			<button id="send-message">Send</button>
+		</p>
+	</div>
+<!-- Push survey dialog -->
+	<div id="push-survey">
+		<p class="directions">
+			Please fill out this <button id="go-survey">quick survey.</button>
+		</p>
+	</div>
+</div>

--- a/templates/push-info.html
+++ b/templates/push-info.html
@@ -1,0 +1,17 @@
+<ul id="push-info" class="push-info standalone" push="{{ int(push_info['id']) }}" pushmaster="{{ escape(push_info['user']) }}" branch="{{ escape(push_info['branch']) }}">
+	<li><span class="label">Pushmaster</span><span class="value">{{ escape(push_info['user']) }}</span></li>
+	<li><span class="label">Branch</span><span class="value">{{ escape(push_info['branch']) }}</span></li>
+{% if push_info['state'] == 'accepting' %}
+	<li><span class="label">Buildbot Runs</span><span class="value"><a href="http://{{ escape(Settings['buildbot']['servername']) }}/branch/{{ escape(push_info['branch']) }}">url</a></span></li>
+{% end %}
+	<li><span class="label">State</span><span class="value"><ul class="tags">
+			<li class="tag-{{ escape(push_info['state']) }}">{{ escape(push_info['state']) }}</li>
+		</ul></span></li>
+	<li><span class="label">Push Type</span><span class="value"><ul class="tags">
+			<li class="tag-{{ escape(push_info['pushtype']) }}">{{ escape(push_info['pushtype']) }}</li>
+		</ul></span></li>
+	<li><span class="label">Created</span><span class="value">{{ datetime.datetime.fromtimestamp(push_info['created']).strftime("%x %X") }}</span></li>
+{% if not push_info['created'] == push_info['modified'] %}
+	<li><span class="label">Modified</span><span class="value">{{ datetime.datetime.fromtimestamp(push_info['modified']).strftime("%x %X") }}</span></li>
+{% end %}
+</ul>

--- a/templates/push-info.html
+++ b/templates/push-info.html
@@ -1,6 +1,7 @@
-<ul id="push-info" class="push-info standalone" push="{{ int(push_info['id']) }}" pushmaster="{{ escape(push_info['user']) }}" branch="{{ escape(push_info['branch']) }}">
+<ul id="push-info" class="push-info standalone" push="{{ int(push_info['id']) }}" pushmaster="{{ escape(push_info['user']) }}" branch="{{ escape(push_info['branch']) }}" stageenv="{% if push_info['stageenv'] %}{{ escape(push_info['stageenv']) }}{% end %}">
 	<li><span class="label">Pushmaster</span><span class="value">{{ escape(push_info['user']) }}</span></li>
 	<li><span class="label">Branch</span><span class="value">{{ escape(push_info['branch']) }}</span></li>
+	{% if push_info['stageenv'] %}<li><span class="label">Stage</span><span class="value">{{ escape(push_info['stageenv']) }}</span></li>{% end %}
 {% if push_info['state'] == 'accepting' %}
 	<li><span class="label">Buildbot Runs</span><span class="value"><a href="http://{{ escape(Settings['buildbot']['servername']) }}/branch/{{ escape(push_info['branch']) }}">url</a></span></li>
 {% end %}

--- a/templates/push-status.html
+++ b/templates/push-status.html
@@ -1,6 +1,6 @@
 <!-- ======== PUSH STATES ========= -->
 {% if push_info['state'] == 'accepting' %}
-{% for (section,sect_title) in [('blessed', 'Deployed to Prod'), ('verified', 'Verified on Stage'),	('staged', 'Deployed to Stage'), ('added', 'Added to Deploy Branch')] %}
+{% for (section,sect_title) in [('blessed', 'Deployed to Prod'), ('verified', 'Verified on %s' % push_info['stageenv']), ('staged', 'Deployed to %s' % push_info['stageenv']), ('added', 'Added to Deploy Branch')] %}
 <h3 class="status-header" section="{{section}}">{{ sect_title }} <span class="item-count"></span>
 	{% if push_info['user'] == current_user or override %}<button class="message-people">msg</button>{% end %}</h3>
 <ul id="{{ section }}-items" class="push-items push-items-section items-in-push">

--- a/templates/push.html
+++ b/templates/push.html
@@ -7,23 +7,7 @@
 	{% include 'edit-push.html' %}
 </div>
 <!-- ========= PUSH INFO ========== -->
-<ul id="push-info" class="push-info standalone" push="{{ int(push_info['id']) }}" pushmaster="{{ escape(push_info['user']) }}" branch="{{ escape(push_info['branch']) }}">
-	<li><span class="label">Pushmaster</span><span class="value">{{ escape(push_info['user']) }}</span></li>
-	<li><span class="label">Branch</span><span class="value">{{ escape(push_info['branch']) }}</span></li>
-{% if push_info['state'] == 'accepting' %}
-	<li><span class="label">Buildbot Runs</span><span class="value"><a href="http://{{ escape(Settings['buildbot']['servername']) }}/branch/{{ escape(push_info['branch']) }}">url</a></span></li>
-{% end %}
-	<li><span class="label">State</span><span class="value"><ul class="tags">
-			<li class="tag-{{ escape(push_info['state']) }}">{{ escape(push_info['state']) }}</li>
-		</ul></span></li>
-	<li><span class="label">Push Type</span><span class="value"><ul class="tags">
-			<li class="tag-{{ escape(push_info['pushtype']) }}">{{ escape(push_info['pushtype']) }}</li>
-		</ul></span></li>
-	<li><span class="label">Created</span><span class="value">{{ datetime.datetime.fromtimestamp(push_info['created']).strftime("%x %X") }}</span></li>
-{% if not push_info['created'] == push_info['modified'] %}
-	<li><span class="label">Modified</span><span class="value">{{ datetime.datetime.fromtimestamp(push_info['modified']).strftime("%x %X") }}</span></li>
-{% end %}
-</ul>
+{% include 'push-info.html' %}
 <!-- ========= BUTTON BAR ========== -->
 <ul id="action-buttons">
 	<li><button id="expand-all-requests">Expand All</button></li>

--- a/templates/push.html
+++ b/templates/push.html
@@ -9,39 +9,7 @@
 <!-- ========= PUSH INFO ========== -->
 {% include 'push-info.html' %}
 <!-- ========= BUTTON BAR ========== -->
-<ul id="action-buttons">
-	<li><button id="expand-all-requests">Expand All</button></li>
-	<li><button id="collapse-all-requests">Collapse All</button></li>
-	&mdash;
-	{% if current_user in (push_info['extra_pings'] or []) %}
-	<li><button id="ping-me" action="unset">Don't Ping Me</button></li>
-	{% else %}
-	<li><button id="ping-me" action="set">Ping Me</button></li>
-	{% end %}
-	{% if push_info['user'] == current_user or override %}
-		&mdash;
-		<li><button id="edit-push">Edit Push</button></li>
-		{% if push_info['state'] == 'accepting' %}
-		<li><button id="discard-push">Discard Push</button></li>
-		&mdash;
-		<li><button id="add-selected-requests">Add Selected</button></li>
-		<li><button id="remove-selected-requests">Remove Selected</button></li>
-		<li><button id="rebuild-deploy-branch">Rebuild Deploy Branch</button></li>
-		&mdash;
-		<li><button id="deploy-to-stage">Added &rarr; Stage</button></li>
-		<li><button id="deploy-to-prod">Stage &rarr; Prod</button></li>
-		<li><button id="merge-to-master">Prod &rarr; master</button></li>
-		&mdash;
-		<li><button id="message-all">Message All</button></li>
-		<li><button id="show-checklist">Push Checklist</button></li>
-		{% end %}
-	{% else %}
-		{% if push_info['state'] == 'accepting' %}
-		&mdash; <li><button id="edit-push">Takeover Push</button></li>
-		{% end %}
-	{% end %}
-	<li style="display: none;">{{ modules.NewRequestDialog() }}</li>
-</ul>
+{% include 'push-button-bar.html' %}
 
 {% include 'push-status.html' %}
 

--- a/templates/push.html
+++ b/templates/push.html
@@ -4,29 +4,7 @@
 
 {% block content %}
 <div id="form-anchor">&nbsp;
-<form id="push-info-form" class="popup-form" action="/editpush" method="POST">
-<div class="form-wrapper">
-	
-	<h2>Edit Push</h2>
-
-	<label for="push-title">Title</label>
-	<input name="push-title" id="push-title" value="{{ escape(push_info['title']) }}" />
-
-	<label for="push-branch">Branch</label>
-	<input name="push-branch" id="push-branch" value="{{ escape(push_info['branch']) }}" />
-
-	<input type="hidden" name="id" value="{{ int(push_info['id']) }}" />
-
-	{% if not push_info['user'] == current_user %}
-	<p id="update-notice">Updating this push will transfer its ownership to you.</p>
-	{% end %}
-
-	<div class="buttons">
-		<input type="submit" id="push-create" name="push-submit" value="Update Push" />
-		<input type="reset" id="push-cancel" name="push-cancel" value="Cancel" />
-	</div>
-</div>
-</form>
+	{% include 'edit-push.html' %}
 </div>
 <!-- ========= PUSH INFO ========== -->
 <ul id="push-info" class="push-info standalone" push="{{ int(push_info['id']) }}" pushmaster="{{ escape(push_info['user']) }}" branch="{{ escape(push_info['branch']) }}">

--- a/templates/push.html
+++ b/templates/push.html
@@ -13,67 +13,8 @@
 
 {% include 'push-status.html' %}
 
-<div id="dialog-prototypes" style="display: none;">
-<!-- "Run a command" dialog -->
-	<div id="run-a-command">
-		<pre id="command-to-run">&nbsp;</pre>
-		<p class="directions">
-			Wait for it to complete, then
-			<button id="command-done">Continue</button>
-		</p>
-		<p class="mininote">
-			(If it fails, click the X or press Esc.)
-		</p>
-	</div>
-<!-- "Comment on a request" dialog -->
-	<div id="comment-on-request">
-		<textarea id="comment-input-area"></textarea>
-		<p class="directions">
-			Enter your comment here, then
-			<button id="submit-request-comment">Submit</button>
-		</p>
-	</div>
-<!-- "Check in multiple requests" dialog -->
-	<div id="merge-requests">
-		<div class="command" id="merge-branches-command">&nbsp;</div>
-		<p class="dialog-note">(Triple-click above to easily select the entire command for copying.)</p>
-		<p class="directions">
-			Once the command completes, click <button id="done-merging">here</button>
-		</p>
-	</div>
-<!-- Push checklist dialog -->
-	<div id="push-checklist">
-		<h4>Before Staging</h4>
-		<ul id="checklist-before-staging">
-			<li><input type="checkbox" /> Foo</li>
-			<li><input type="checkbox" /> Foo</li>
-		</ul>
-		<h4>Before Blessing</h4>
-		<ul id="checklist-before-blessing">
-			<li><input type="checkbox" /> Foo</li>
-			<li><input type="checkbox" /> Foo</li>
-		</ul>
-		<h4>After Live</h4>
-		<ul id="checklist-after-live">
-			<li><input type="checkbox" /> Foo</li>
-			<li><input type="checkbox" /> Foo</li>
-		</ul>
-	</div>
-<!-- Messaging dialog -->
-	<div id="send-message-prompt">
-		<input id="send-message-contents" />
-		<p class="directions">
-			Enter the message you wish to send here, then
-			<button id="send-message">Send</button>
-		</p>
-	</div>
-<!-- Push survey dialog -->
-	<div id="push-survey">
-		<p class="directions">
-			Please fill out this <button id="go-survey">quick survey.</button>
-		</p>
-	</div>
-</div>
+{% include 'push-dialogs.html' %}
+
 {% end %}
 
 {% block scripts %}

--- a/testing/testdb.py
+++ b/testing/testdb.py
@@ -40,13 +40,13 @@ class FakeDataMixin(object):
     yesterday = time.mktime((datetime.now() - timedelta(days=1)).timetuple())
 
     push_data = [
-        [10, 'OnePush', 'bmetin', 'deploy-1', 'abc', 'live', yesterday, now, 'regular', ''],
-        [11, 'TwoPush', 'troscoe', 'deploy-2', 'def', 'accepting', now, now, 'regular', ''],
-        [12, 'RedPush', 'heyjoe', 'deploy-3', 'ghi', 'accepting', now, now, 'regular', ''],
-        [13, 'BluePush', 'humpty', 'deploy-4', 'jkl', 'accepting', now, now, 'regular', ''],
+        [10, 'OnePush', 'bmetin', 'deploy-1', '', 'abc', 'live', yesterday, now, 'regular', ''],
+        [11, 'TwoPush', 'troscoe', 'deploy-2', '', 'def', 'accepting', now, now, 'regular', ''],
+        [12, 'RedPush', 'heyjoe', 'deploy-3', '', 'ghi', 'accepting', now, now, 'regular', ''],
+        [13, 'BluePush', 'humpty', 'deploy-4', '', 'jkl', 'accepting', now, now, 'regular', ''],
     ]
     push_keys = [
-        'id', 'title', 'user', 'branch', 'revision', 'state',
+        'id', 'title', 'user', 'branch', 'stageenv', 'revision', 'state',
         'created', 'modified', 'pushtype', 'extra_pings'
     ]
 

--- a/testing/testdb.sql
+++ b/testing/testdb.sql
@@ -15,6 +15,7 @@ CREATE TABLE push_pushes (
 	modified INTEGER,
 	pushtype VARCHAR,
 	extra_pings VARCHAR,
+	stageenv VARCHAR,
 	PRIMARY KEY (id)
 );
 INSERT INTO "push_pushes" VALUES(
@@ -27,6 +28,7 @@ INSERT INTO "push_pushes" VALUES(
        1346458516.87736,
        1346458516.87736,
        'regular',
+       NULL,
        NULL
 );
 INSERT INTO "push_pushes" VALUES(2,
@@ -38,6 +40,7 @@ INSERT INTO "push_pushes" VALUES(2,
        1346458663.2721,
        1346458663.2721,
        'private',
+       NULL,
        NULL
 );
 CREATE TABLE push_pushcontents (

--- a/tests/test_servlet_deploypush.py
+++ b/tests/test_servlet_deploypush.py
@@ -50,7 +50,7 @@ class DeployPushServletTest(T.TestCase, T.ServletTestMixin):
         reqs = [no_watcher_req, watched_req]
 
         def fetchone():
-            return {'extra_pings': None}
+            return {'extra_pings': None, 'stageenv': None}
 
         res = mock.Mock()
         res.fetchone = fetchone

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -9,6 +9,7 @@ class PushTemplateTest(T.TemplateTestCase):
     push_status_page = 'push-status.html'
 
     accepting_push_sections = ['blessed', 'verified', 'staged', 'added', 'pickme', 'requested']
+    now = time.time()
 
     now = time.time()
 
@@ -49,6 +50,24 @@ class PushTemplateTest(T.TemplateTestCase):
             'comments': 'nocomment',
             'watchers': None,
             }
+
+    basic_request = {
+            'id': 0,
+            'repo': 'non-existent',
+            'branch': 'non-existent',
+            'user': 'testuser',
+            'reviewid': 0,
+            'title': 'some title',
+            'tags': None,
+            'revision': '0' * 40,
+            'state': 'requested',
+            'created': now,
+            'modified': now,
+            'description': 'nondescript',
+            'comments': 'nocomment',
+            'watchers': None,
+            }
+
 
     def test_include_push_status_when_accepting(self):
         tree = self.render_etree(
@@ -216,6 +235,19 @@ class PushTemplateTest(T.TemplateTestCase):
         T.assert_exactly_one(
                 *[mock.attrib['name'] for mock in tree.iter('mock')],
                 truthy_fxn=lambda name: name == 'mock.NewRequestDialog()')
+
+    def test_include_edit_push(self):
+        tree = self.render_etree(
+            self.push_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+
+        found_form = []
+        for form in tree.iter('form'):
+            if form.attrib['id'] ==  'push-info-form':
+                found_form.append(form)
+
+        T.assert_equal(len(found_form), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -1,5 +1,6 @@
 import time
 
+from core.settings import Settings
 import testing as T
 
 class PushTemplateTest(T.TemplateTestCase):
@@ -7,6 +8,7 @@ class PushTemplateTest(T.TemplateTestCase):
     authenticated = True
     push_page = 'push.html'
     push_status_page = 'push-status.html'
+    push_info_page = 'push-info.html'
 
     accepting_push_sections = ['blessed', 'verified', 'staged', 'added', 'pickme', 'requested']
     now = time.time()
@@ -68,6 +70,27 @@ class PushTemplateTest(T.TemplateTestCase):
             'watchers': None,
             }
 
+    basic_push_info_items = {
+            'Pushmaster': basic_push['user'],
+            'Branch': basic_push['branch'],
+            'Buildbot Runs': 'http://%s/branch/%s' % (Settings['buildbot']['servername'], basic_push['branch']),
+            'State': basic_push['state'],
+            'Push Type': basic_push['pushtype'],
+            'Created': time.strftime("%x %X", time.localtime(basic_push['created']))
+    }
+
+    def test_include_push_info(self):
+        tree = self.render_etree(
+            self.push_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+
+        found_ul = []
+        for ul in tree.iter('ul'):
+            if 'id' in ul.attrib and ul.attrib['id'] == 'push-info':
+                found_ul.append(ul)
+
+        T.assert_equal(1, len(found_ul))
 
     def test_include_push_status_when_accepting(self):
         tree = self.render_etree(
@@ -248,6 +271,65 @@ class PushTemplateTest(T.TemplateTestCase):
                 found_form.append(form)
 
         T.assert_equal(len(found_form), 1)
+
+    push_info_items = [
+        'Pushmaster', 'Branch', 'Buildbot Runs',
+        'State', 'Push Type', 'Created', 'Modified'
+    ]
+
+    def assert_push_info_list(self, list_items, push_info_items):
+        for li in list_items:
+            T.assert_in(li[0].text, push_info_items.keys())
+            if li[0].text == 'Buildbot Runs':
+                T.assert_equal(li[1][0].text, 'url')
+                T.assert_equal(li[1][0].attrib['href'], push_info_items['Buildbot Runs'])
+            elif li[0].text == 'State':
+                T.assert_equal(li[1][0].attrib['class'], 'tags')  # Inner ul
+                T.assert_equal(li[1][0][0].attrib['class'], 'tag-%s' % push_info_items['State'])  # Inner li
+                T.assert_equal(li[1][0][0].text, push_info_items['State'])
+            elif li[0].text == 'Push Type':
+                T.assert_equal(li[1][0].attrib['class'], 'tags')  # Inner ul
+                T.assert_equal(li[1][0][0].attrib['class'], 'tag-%s' % push_info_items['Push Type'])  # Inner li
+                T.assert_equal(li[1][0][0].text, push_info_items['Push Type'])
+            else:
+                T.assert_equal(li[1].text, push_info_items[li[0].text])
+
+        T.assert_equal(len(list_items), len(push_info_items))
+
+    def test_push_info_list_items(self):
+        tree = self.render_etree(
+            self.push_info_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+
+        self.assert_push_info_list(list(tree.iter('ul'))[0], self.basic_push_info_items)
+
+    def test_push_info_list_items_modified(self):
+        push = dict(self.basic_push)
+        push['modified'] = time.time()
+        tree = self.render_etree(
+            self.push_info_page,
+            push_info=push,
+            **self.basic_kwargs)
+
+        push_info_items = dict(self.basic_push_info_items)
+        push_info_items['Modified'] = time.strftime("%x %X", time.localtime(push['modified']))
+
+        self.assert_push_info_list(list(tree.iter('ul'))[0], push_info_items)
+
+    def test_push_info_list_items_notaccepting(self):
+        push = dict(self.basic_push)
+        push['state'] = 'live'
+        tree = self.render_etree(
+            self.push_info_page,
+            push_info=push,
+            **self.basic_kwargs)
+
+        push_info_items = dict(self.basic_push_info_items)
+        push_info_items['State'] = 'live'
+        del push_info_items['Buildbot Runs']
+
+        self.assert_push_info_list(list(tree.iter('ul'))[0], push_info_items)
 
 
 if __name__ == '__main__':

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -13,7 +13,6 @@ class PushTemplateTest(T.TemplateTestCase):
     push_dialogs_page = 'push-dialogs.html'
 
     accepting_push_sections = ['blessed', 'verified', 'staged', 'added', 'pickme', 'requested']
-    now = time.time()
 
     now = time.time()
 

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -9,6 +9,7 @@ class PushTemplateTest(T.TemplateTestCase):
     push_page = 'push.html'
     push_status_page = 'push-status.html'
     push_info_page = 'push-info.html'
+    push_button_bar_page = 'push-button-bar.html'
 
     accepting_push_sections = ['blessed', 'verified', 'staged', 'added', 'pickme', 'requested']
     now = time.time()
@@ -88,6 +89,19 @@ class PushTemplateTest(T.TemplateTestCase):
         found_ul = []
         for ul in tree.iter('ul'):
             if 'id' in ul.attrib and ul.attrib['id'] == 'push-info':
+                found_ul.append(ul)
+
+        T.assert_equal(1, len(found_ul))
+
+    def test_include_push_button_bar(self):
+        tree = self.render_etree(
+            self.push_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+
+        found_ul = []
+        for ul in tree.iter('ul'):
+            if 'id' in ul.attrib and ul.attrib['id'] == 'action-buttons':
                 found_ul.append(ul)
 
         T.assert_equal(1, len(found_ul))
@@ -330,6 +344,48 @@ class PushTemplateTest(T.TemplateTestCase):
         del push_info_items['Buildbot Runs']
 
         self.assert_push_info_list(list(tree.iter('ul'))[0], push_info_items)
+
+    push_button_ids_base = ['expand-all-requests', 'collapse-all-requests', 'ping-me', 'edit-push']
+    push_button_ids_pushmaster = [
+            'discard-push', 'add-selected-requests',
+            'remove-selected-requests', 'rebuild-deploy-branch',
+            'deploy-to-stage', 'deploy-to-prod', 'merge-to-master',
+            'message-all', 'show-checklist']
+
+    def test_push_buttons_random_user(self):
+        with self.no_ui_modules():
+            tree = self.render_etree(
+                self.push_button_bar_page,
+                push_info=self.basic_push,
+                **self.basic_kwargs)
+
+        found_buttons = []
+        for button in tree.iter('button'):
+            T.assert_in(button.attrib['id'], self.push_button_ids_base)
+            found_buttons.append(button)
+
+        T.assert_equal(len(found_buttons), len(self.push_button_ids_base))
+
+    def test_push_buttons_pushmaster(self):
+        kwargs = dict(self.basic_kwargs)
+        kwargs['current_user'] = self.basic_push['user']
+
+        with self.no_ui_modules():
+            tree = self.render_etree(
+                self.push_button_bar_page,
+                push_info=self.basic_push,
+                **kwargs)
+
+        found_buttons = []
+        for button in tree.iter('button'):
+            T.assert_in(
+                    button.attrib['id'],
+                    self.push_button_ids_base + self.push_button_ids_pushmaster)
+            found_buttons.append(button)
+
+        T.assert_equal(
+                len(found_buttons),
+                len(self.push_button_ids_base + self.push_button_ids_pushmaster))
 
 
 if __name__ == '__main__':

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -10,6 +10,7 @@ class PushTemplateTest(T.TemplateTestCase):
     push_status_page = 'push-status.html'
     push_info_page = 'push-info.html'
     push_button_bar_page = 'push-button-bar.html'
+    push_dialogs_page = 'push-dialogs.html'
 
     accepting_push_sections = ['blessed', 'verified', 'staged', 'added', 'pickme', 'requested']
     now = time.time()
@@ -286,6 +287,19 @@ class PushTemplateTest(T.TemplateTestCase):
 
         T.assert_equal(len(found_form), 1)
 
+    def test_include_dialogs(self):
+        tree = self.render_etree(
+            self.push_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+
+        found_divs = []
+        for div in tree.iter('div'):
+            if 'id' in div.attrib and div.attrib['id'] ==  'dialog-prototypes':
+                found_divs.append(div)
+
+        T.assert_equal(len(found_divs), 1)
+
     push_info_items = [
         'Pushmaster', 'Branch', 'Buildbot Runs',
         'State', 'Push Type', 'Created', 'Modified'
@@ -386,6 +400,26 @@ class PushTemplateTest(T.TemplateTestCase):
         T.assert_equal(
                 len(found_buttons),
                 len(self.push_button_ids_base + self.push_button_ids_pushmaster))
+
+    dialog_ids = [
+            'dialog-prototypes',
+            'run-a-command', 'comment-on-request', 'merge-requests',
+            'merge-branches-command', 'push-checklist', 'send-message-prompt',
+            'push-survey',
+    ]
+
+    def test_dialogs_divs(self):
+        tree = self.render_etree(
+            self.push_dialogs_page,
+            push_info=self.basic_push,
+            **self.basic_kwargs)
+
+        found_divs = []
+        for div in tree.iter('div'):
+            T.assert_in(div.attrib['id'], self.dialog_ids)
+            found_divs.append(div)
+
+        T.assert_equal(len(found_divs),len(self.dialog_ids))
 
 
 if __name__ == '__main__':

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -27,6 +27,7 @@ class PushTemplateTest(T.TemplateTestCase):
             'created': now,
             'modified': now,
             'extra_pings': None,
+            'stageenv': None,
         }
 
     basic_kwargs = {
@@ -359,11 +360,24 @@ class PushTemplateTest(T.TemplateTestCase):
 
         self.assert_push_info_list(list(tree.iter('ul'))[0], push_info_items)
 
+    def test_push_info_list_items_stageenv(self):
+        push = dict(self.basic_push)
+        push['stageenv'] = 'stageenv'
+        tree = self.render_etree(
+            self.push_info_page,
+            push_info=push,
+            **self.basic_kwargs)
+
+        push_info_items = dict(self.basic_push_info_items)
+        push_info_items['Stage'] = 'stageenv'
+
+        self.assert_push_info_list(list(tree.iter('ul'))[0], push_info_items)
+
     push_button_ids_base = ['expand-all-requests', 'collapse-all-requests', 'ping-me', 'edit-push']
     push_button_ids_pushmaster = [
             'discard-push', 'add-selected-requests',
             'remove-selected-requests', 'rebuild-deploy-branch',
-            'deploy-to-stage', 'deploy-to-prod', 'merge-to-master',
+            'deploy-to-stage-step0', 'deploy-to-prod', 'merge-to-master',
             'message-all', 'show-checklist']
 
     def test_push_buttons_random_user(self):
@@ -405,7 +419,7 @@ class PushTemplateTest(T.TemplateTestCase):
             'dialog-prototypes',
             'run-a-command', 'comment-on-request', 'merge-requests',
             'merge-branches-command', 'push-checklist', 'send-message-prompt',
-            'push-survey',
+            'push-survey', 'set-stageenv-prompt',
     ]
 
     def test_dialogs_divs(self):

--- a/tests/test_template_pushes.py
+++ b/tests/test_template_pushes.py
@@ -1,0 +1,29 @@
+import testing as T
+
+class PushesTemplateTest(T.TemplateTestCase):
+
+    authenticated = True
+    pushes_page = 'pushes.html'
+    new_push_page = 'new-push.html'
+
+    def render_pushes_page(self, page_title='Pushes', pushes=[], pushes_per_page=50, last_push=None):
+        return self.render_etree(self.pushes_page,
+            page_title=page_title,
+            pushes=pushes,
+            rpp=pushes_per_page,
+            last_push=last_push
+        )
+
+    def test_include_new_push(self):
+        tree = self.render_pushes_page()
+
+        found_form = []
+        for form in tree.iter('form'):
+            if form.attrib['id'] == 'push-info-form':
+                found_form.append(form)
+
+        T.assert_equal(len(found_form), 1)
+
+
+if __name__ == '__main__':
+    T.run()


### PR DESCRIPTION
Let the pushmaster specify a stage environment. This value will be used in emails, notifications, and the push page. This gives those involved in the push additional information.

The pushmaster will be required to specify the stage environment on each 'Added -> stage' button press.

Drawbacks: the push page isn't updated with the stageenv until a refresh is made. We don't currently force refreshes for these push actions.
