### PR TITLE
Use https for buildbot links

### DIFF
--- a/static/js/modules/request.js
+++ b/static/js/modules/request.js
@@ -115,7 +115,7 @@ $(function() {
     $('.discard-request').live('click', PushManager.Request.discard_request);
 
     PushManager.Request.load_bb_failures = function(domobj) {
-        var dataurl = "http://" + Settings['buildbot']['servername'] + "/rev/%REVISION%";
+        var dataurl = "https://" + Settings['buildbot']['servername'] + "/rev/%REVISION%";
         var that = $(domobj);
         if(that.hasClass('bb-data-loaded')) {
             return;

--- a/tests/test_servlet_push.py
+++ b/tests/test_servlet_push.py
@@ -66,7 +66,7 @@ class PushServletTest(PushServletTestBase):
             requests = pushdata[1]
             all_requests = requests['all']
             first_request = all_requests[0]
-            buildbot_link = "http://%s/rev/%s" % (Settings['buildbot']['servername'], first_request['revision'])
+            buildbot_link = "https://%s/rev/%s" % (Settings['buildbot']['servername'], first_request['revision'])
             T.assert_equal(self.find_buildbot_link(response, buildbot_link), True)
 
 

--- a/tests/test_template_push.py
+++ b/tests/test_template_push.py
@@ -75,7 +75,7 @@ class PushTemplateTest(T.TemplateTestCase):
     basic_push_info_items = {
             'Pushmaster': basic_push['user'],
             'Branch': basic_push['branch'],
-            'Buildbot Runs': 'http://%s/branch/%s' % (Settings['buildbot']['servername'], basic_push['branch']),
+            'Buildbot Runs': 'https://%s/branch/%s' % (Settings['buildbot']['servername'], basic_push['branch']),
             'State': basic_push['state'],
             'Push Type': basic_push['pushtype'],
             'Created': time.strftime("%x %X", time.localtime(basic_push['created']))

--- a/ui_modules.py
+++ b/ui_modules.py
@@ -66,7 +66,7 @@ class Request(UIModule):
         tags = dict((tag, None) for tag in (request['tags'].split(',') if request['tags'] else []))
 
         if 'buildbot' in tags:
-            tags['buildbot'] = "http://%s/rev/%s" % (Settings['buildbot']['servername'], request['revision'])
+            tags['buildbot'] = "https://%s/rev/%s" % (Settings['buildbot']['servername'], request['revision'])
 
         if 'pushplans' in tags:
             tags['pushplans'] = "https://%s/?p=%s.git;a=history;f=pushplans;hb=refs/heads/%s" % (


### PR DESCRIPTION
Some browsers will prevent buildbot queries when pushmanager runs as
https and buildbot is accessed via http.
