### PR TITLE
Add git conflict detection

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -74,6 +74,7 @@ git:
     gitweb_servername: "gitweb.example.com"
     main_repository: "main-repository"
     dev_repositories_dir: "devs"
+    local_repo_path: "/place/to/store/on-disk/git/repos/"
     # A background worker tries to verify the given branch in a push
     # request by checking the SHA of the branch in the repository and
     # in DB - to see if there was already a request for the

--- a/pushmanager/core/db.py
+++ b/pushmanager/core/db.py
@@ -86,6 +86,7 @@ class PushRequests(Base):
     branch = Column(String)
     revision = Column(String(40), nullable=True)
     tags = Column(String)
+    conflicts = Column(String)
     created = Column(Integer, nullable=True)
     modified = Column(Integer, nullable=True)
     title = Column(String)

--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from . import db
 from .mail import MailQueue
+import os
 import logging
 from Queue import Queue
 import subprocess
@@ -53,6 +54,58 @@ class GitQueue(object):
         cls.worker_thread.start()
 
     @classmethod
+    def create_or_update_local_repo(cls, repo_name, branch):
+        """
+        Clones or fetches the repository specified by repo_name into the local_repo_path
+        speficied in the configuration.
+        If branch is specified, it will also checkout that branch.
+        """
+
+        repo_path = cls._get_local_repository_uri(repo_name)
+
+        if not os.path.isdir(repo_path):
+            # Clone the main repo into repo_path. Will take time!
+            clone_repo = GitCommand(
+                'clone',
+                cls._get_repository_uri(repo_name),
+                repo_path
+            )
+            rc, stdout, stderr = clone_repo.run()
+            if rc:
+                logging.error("Failed to create local clone with code %d: %s" % (rc, stderr))
+                return rc
+
+        # Fetch all new repo info
+        fetch_updates = GitCommand('fetch', '--all', cwd=repo_path)
+        rc, stdout, stderr = fetch_updates.run()
+        if rc:
+            logging.error("Failed to update local git repo (code %d): %s" % (rc, stderr))
+            return rc
+
+        # Checkout the branch
+        checkout_branch = GitCommand('checkout', branch, cwd=repo_path)
+        rc, stdout, stderr = checkout_branch.run()
+        if rc:
+            logging.error(
+                "Failed to check out branch %s from %s (code %d): %s"
+                % (branch, repo_name, rc, stderr)
+            )
+            return rc
+
+        # Try to fast-forward any updates to the branch
+        fetch_updates = GitCommand('pull', '--ff-only', cwd=repo_path)
+        rc, stdout, stderr = fetch_updates.run()
+        if rc:
+            logging.error("Failed to update local git repo (code %d): %s" % (rc, stderr))
+            return rc
+
+        return 0
+
+    @classmethod
+    def _get_local_repository_uri(cls, repository):
+        return os.path.join(Settings['git']['local_repo_path'], repository)
+
+    @classmethod
     def _get_repository_uri(cls, repository):
         scheme = Settings['git']['scheme']
         netloc = Settings['git']['servername']
@@ -68,8 +121,11 @@ class GitQueue(object):
 
     @classmethod
     def _get_branch_sha_from_repo(cls, req):
+        # Update local copy of the repo
+        cls.create_or_update_local_repo(req['repo'], branch=req['branch'])
+
         user_to_notify = req['user']
-        repository = cls._get_repository_uri(req['repo'])
+        repository = cls._get_local_repository_uri(req['repo'])
         ls_remote = GitCommand('ls-remote', '-h', repository, req['branch'])
         rc, stdout, stderr = ls_remote.run()
         stdout = stdout.strip()

--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -16,6 +16,158 @@ import urllib2
 
 from pushmanager.core.settings import Settings
 
+class GitBranchContextManager(object):
+    """
+    Context manager that creates / deletes a temporary git branch
+
+    :param test_branch: The name of the temporary branch to create
+    :param master_repo_path: The on-disk path to the master repository
+    """
+
+    def __init__(self, test_branch, master_repo_path):
+        self.test_branch = test_branch
+        self.master_repo_path = master_repo_path
+
+    def __enter__(self):
+        # Create a new branch tracking master
+        make_test_branch = GitCommand(
+            "checkout",
+            "origin/master",
+            "-b",
+            self.test_branch,
+            cwd=self.master_repo_path
+        )
+        rc, stdout, stderr = make_test_branch.run()
+        if rc:
+            raise Exception(
+                "GitBranchContextManager",
+                "Failed to create test branch: %s" % stderr
+            )
+
+    def __exit__(self, type, value, traceback):
+        # Checkout master so that we can delete the test branch
+        checkout_master = GitCommand(
+            "checkout",
+            "master",
+            cwd = self.master_repo_path
+        )
+        rc, stdout, stderr = checkout_master.run()
+        if rc:
+            raise Exception(
+                "GitBranchContextManager",
+                "Unable to checkout master: %s"
+                % self.test_branch
+            )
+
+        # Delete the branch that we were working on
+        delete_test_branch = GitCommand(
+            "branch",
+            "-D",
+            self.test_branch,
+            cwd = self.master_repo_path
+        )
+        rc, stdout, stderr = delete_test_branch.run()
+        if rc:
+            raise Exception(
+                "GitBranchContextManager",
+                "Unable to delete test branch: %s"
+                % self.test_branch
+            )
+
+def git_reset_to_ref(starting_ref, git_directory):
+    """
+    Resets a git repo to the specified ref.
+    Called as a cleanup fn by GitMergeContextManager.
+
+    :param starting_ref: Git hash of the commit to roll back to
+    """
+
+    reset_command = GitCommand(
+        "reset",
+        "--hard",
+        starting_ref,
+        cwd = git_directory
+    )
+    return reset_command.run()
+
+class GitMergeContextManager(object):
+    """
+    Contest manager for merging that rolls back on __exit__
+
+    :param test_branch: The name of the branch to merge onto
+    :param master_repo_path: The on-disk path to the master repository
+    :param pickme_request: A dictionary containing the details of the pickme
+    """
+
+    def __init__(self, test_branch, master_repo_path, pickme_request):
+        self.test_branch = test_branch
+        self.master_repo_path = master_repo_path
+        self.pickme_request = pickme_request
+
+    def __enter__(self):
+        # Store the starting ref so that we can hard reset if need be
+        get_starting_ref = GitCommand(
+            "rev-parse",
+            self.test_branch,
+            cwd=self.master_repo_path
+        )
+        rc, stdout, stderr = get_starting_ref.run()
+        if rc:
+            raise Exception(
+                "GitContextManager",
+                "Failed to get current ref: %s" % stderr
+            )
+        self.starting_ref = stdout.strip()
+
+        # Locate and merge the branch we are testing
+        devrepo = "devs/%s" % self.pickme_request['branch']
+        summary = "{branch_title}\n\n(Merged from {user}/{branch})".format(
+            branch_title = self.pickme_request['title'],
+            user = self.pickme_request['user'],
+            branch = self.pickme_request['branch']
+        )
+        pickme_repo_uri = "/var/lib/pushmanager/repos/%s" % self.pickme_request['user']
+        pull_command = GitCommand(
+            "pull",
+            "--no-ff",
+            "--no-commit",
+            pickme_repo_uri,
+            self.pickme_request['branch'],
+            cwd = self.master_repo_path)
+        rc, stdout, stderr = pull_command.run()
+        if rc:
+            git_reset_to_ref(self.starting_ref, self.master_repo_path)
+            raise Exception(
+                "GitContextManager",
+                "Unable to merge branch %s" % self.pickme_request['branch']
+            )
+
+        ##TODO: Submodules
+
+        commit_command = GitCommand("commit", "-m", summary, "--no-verify", cwd=self.master_repo_path)
+        rc, stdout, stderr = commit_command.run()
+        if rc:
+            git_reset_to_ref(self.starting_ref, self.master_repo_path)
+            raise Exception(
+                "GitContextManager",
+                "Committing branch %s failed! One possible cause: a branch which contains no changes (nothing to commit)"
+                % self.pickme_request['branch']
+            )
+
+    def __exit__(self, type, value, traceback):
+        rc, stdout, stderr = git_reset_to_ref(
+            self.starting_ref,
+            self.master_repo_path
+        )
+        if rc:
+            raise Exception(
+                "GitContextManager",
+                "Failed to reset branch %s: %s"
+                % (self.pickme_request['branch'], stderr)
+            )
+
+
+
 class GitTaskAction:
     VERIFY_BRANCH, TEST_PICKME_CONFLICT = range(2)
 

--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -16,6 +16,24 @@ import urllib2
 
 from pushmanager.core.settings import Settings
 
+class GitException(Exception):
+    """
+    Exception class to be thrown by Git Context managers.
+    Has fields for git output on top of  basic exception information.
+
+    :param gitrc: Return code from the failing Git process
+    :param gitout: Stdout for the git process
+    :param giterr: Stderr for the git process
+    """
+    def __init__(self, details, gitrc=None, gitout=None, giterr=None):
+        self.details = details
+        self.gitrc = gitrc
+        self.gitout = gitout
+        self.giterr = giterr
+
+    def __str__(self):
+        return repr(self.details)
+
 class GitBranchContextManager(object):
     """
     Context manager that creates / deletes a temporary git branch
@@ -39,9 +57,11 @@ class GitBranchContextManager(object):
         )
         rc, stdout, stderr = make_test_branch.run()
         if rc:
-            raise Exception(
-                "GitBranchContextManager",
-                "Failed to create test branch: %s" % stderr
+            raise GitException(
+                "GitBranchContextManager: Failed to create test branch: %s" % stderr,
+                gitrc = rc,
+                gitout = stdout,
+                giterr = stderr
             )
 
     def __exit__(self, type, value, traceback):
@@ -53,10 +73,11 @@ class GitBranchContextManager(object):
         )
         rc, stdout, stderr = checkout_master.run()
         if rc:
-            raise Exception(
-                "GitBranchContextManager",
-                "Unable to checkout master: %s"
-                % self.test_branch
+            raise GitException(
+                "GitBranchContextManager: Unable to checkout master: %s" % stderr,
+                gitrc = rc,
+                gitout = stdout,
+                giterr = stderr
             )
 
         # Delete the branch that we were working on
@@ -68,10 +89,11 @@ class GitBranchContextManager(object):
         )
         rc, stdout, stderr = delete_test_branch.run()
         if rc:
-            raise Exception(
-                "GitBranchContextManager",
-                "Unable to delete test branch: %s"
-                % self.test_branch
+            raise GitException(
+                "GitBranchContextManager: Unable to delete test branch: %s" % self.test_branch,
+                gitrc = rc,
+                gitout = stdout,
+                giterr = stderr
             )
 
 def git_reset_to_ref(starting_ref, git_directory):
@@ -113,9 +135,11 @@ class GitMergeContextManager(object):
         )
         rc, stdout, stderr = get_starting_ref.run()
         if rc:
-            raise Exception(
-                "GitContextManager",
-                "Failed to get current ref: %s" % stderr
+            raise GitException(
+                "GitMergeContextManager: Failed to get current ref: %s" % stderr,
+                gitrc = rc,
+                gitout = stdout,
+                giterr = stderr
             )
         self.starting_ref = stdout.strip()
 
@@ -137,9 +161,11 @@ class GitMergeContextManager(object):
         rc, stdout, stderr = pull_command.run()
         if rc:
             git_reset_to_ref(self.starting_ref, self.master_repo_path)
-            raise Exception(
-                "GitContextManager",
-                "Unable to merge branch %s" % self.pickme_request['branch']
+            raise GitException(
+                "GitMergeContextManager: Unable to merge branch %s" % self.pickme_request['branch'],
+                gitrc = rc,
+                gitout = stdout,
+                giterr = stderr
             )
 
         ##TODO: Submodules
@@ -148,10 +174,12 @@ class GitMergeContextManager(object):
         rc, stdout, stderr = commit_command.run()
         if rc:
             git_reset_to_ref(self.starting_ref, self.master_repo_path)
-            raise Exception(
-                "GitContextManager",
-                "Committing branch %s failed! One possible cause: a branch which contains no changes (nothing to commit)"
-                % self.pickme_request['branch']
+            raise GitException(
+                "GitMergeContextManager: Committing branch %s failed! One possible cause: a branch which contains no changes (nothing to commit)"
+                % self.pickme_request['branch'],
+                gitrc = rc,
+                gitout = stdout,
+                giterr = stderr
             )
 
     def __exit__(self, type, value, traceback):
@@ -160,10 +188,11 @@ class GitMergeContextManager(object):
             self.master_repo_path
         )
         if rc:
-            raise Exception(
-                "GitContextManager",
-                "Failed to reset branch %s: %s"
-                % (self.pickme_request['branch'], stderr)
+            raise GitException(
+                "GitMergeContextManager: Failed to reset branch %s: %s" % (self.pickme_request['branch'], stderr),
+                gitrc = rc,
+                gitout = stdout,
+                giterr = stderr
             )
 
 
@@ -514,19 +543,20 @@ class GitQueue(object):
                             try:
                                 with GitMergeContextManager(target_branch, repo_path, pickme_details):
                                     pass
-                            except Exception, e:
-                                conflict_pickmes.append((pickme, e))
+                            except GitException, e:
+                                conflict_pickmes.append((pickme, e.gitout, e.giterr))
 
                     logging.info("Pickme %s conflicted with %d pickmes: %s"
                         % (request_id, len(conflict_pickmes), conflict_pickmes))
                     if len(conflict_pickmes) > 0:
                         updated_tags = add_to_tags_str(updated_tags, 'conflict-pickme')
                     formatted_conflicts = "";
-                    for broken_pickme, error in conflict_pickmes:
+                    for broken_pickme, git_out, git_err in conflict_pickmes:
                         pickme_details = cls._get_request(broken_pickme)
-                        formatted_pickme_err = "Conflict with <a href='/request?id={pickme_id}'>{pickme_name}</a>: <br/>{pickme_err}<br/><br/>".format(
+                        formatted_pickme_err = "Conflict with <a href='/request?id={pickme_id}'>{pickme_name}</a>: <br/>{pickme_out}<br/>{pickme_err}<br/><br/>".format(
                             pickme_id = broken_pickme,
-                            pickme_err = error,
+                            pickme_err = git_err,
+                            pickme_out = git_out,
                             pickme_name = pickme_details['title']
                         )
                         formatted_conflicts += formatted_pickme_err
@@ -541,13 +571,13 @@ class GitQueue(object):
                         logging.error("Failed to update pickme")
 
 
-            except Exception, e:
+            except GitException, e:
                 logging.info("Pickme %s conflicted with master: %s"
                         % (request_id, repr(e)))
                 updated_tags = add_to_tags_str(updated_tags, 'conflict-master')
                 updated_values = {
                         'tags': updated_tags,
-                        'conflicts': "<strong>Conflict with master:</strong><br/> %s" % repr(e)
+                        'conflicts': "<strong>Conflict with master:</strong><br/> %s" % e.gitout
                     }
 
                 updated_request = cls._update_request(req, updated_values)

--- a/pushmanager/core/util.py
+++ b/pushmanager/core/util.py
@@ -4,12 +4,20 @@ import datetime
 from tornado.escape import xhtml_escape
 
 class EscapedDict:
-    """A wrapper for a dict that HTML-escapes values as you ask for them"""
+    """
+    A wrapper for a dict that HTML-escapes values as you ask for them
+    Keys prefixed with no_escape_ will not be escaped
+    """
     def __init__(self, doc):
         self.doc = doc
     def __getitem__(self, key):
+        escape = True
+        if key.startswith("no_escape_"):
+            escape = False
+            key = key[len("no_escape_"):]
+
         item = self.doc[key]
-        if isinstance(item, str):
+        if isinstance(item, str) and escape:
             return xhtml_escape(self.doc[key])
         else:
             return self.doc[key]

--- a/pushmanager/core/util.py
+++ b/pushmanager/core/util.py
@@ -154,6 +154,7 @@ def request_to_jsonable(request):
             'branch',
             'revision',
             'tags',
+            'conflicts',
             'created',
             'modified',
             'title',

--- a/pushmanager/servlets/newrequest.py
+++ b/pushmanager/servlets/newrequest.py
@@ -3,7 +3,7 @@ import time
 import re
 
 import pushmanager.core.db as db
-from pushmanager.core.git import GitQueue
+from pushmanager.core.git import GitQueue, GitTaskAction
 from pushmanager.core.requesthandler import RequestHandler
 import pushmanager.core.util
 
@@ -138,6 +138,6 @@ class NewRequestServlet(RequestHandler):
             return self.send_error(500)
 
         if self.requestid:
-            GitQueue.enqueue_request(self.requestid)
+            GitQueue.enqueue_request(GitTaskAction.VERIFY_BRANCH, self.requestid)
 
         return self.redirect("/requests?user=%s" % self.request_user)

--- a/pushmanager/servlets/pickmerequest.py
+++ b/pushmanager/servlets/pickmerequest.py
@@ -88,3 +88,4 @@ class UnpickMeRequestServlet(RequestHandler):
 
     def on_db_complete(self, success, db_results):
         self.check_db_results(success, db_results)
+        GitQueue.enqueue_request(GitTaskAction.TEST_ALL_PICKMES, self.pushid)

--- a/pushmanager/servlets/pickmerequest.py
+++ b/pushmanager/servlets/pickmerequest.py
@@ -2,6 +2,7 @@ import sqlalchemy as SA
 
 import pushmanager.core.db as db
 from pushmanager.core.requesthandler import RequestHandler
+from pushmanager.core.git import GitQueue, GitTaskAction
 import pushmanager.core.util
 
 class PickMeRequestServlet(RequestHandler):
@@ -57,6 +58,8 @@ class PickMeRequestServlet(RequestHandler):
 
     def on_db_complete(self, success, db_results):
         self.check_db_results(success, db_results)
+        for request_id in self.request_ids:
+            GitQueue.enqueue_request(GitTaskAction.TEST_PICKME_CONFLICT, request_id)
 
 class UnpickMeRequestServlet(RequestHandler):
 

--- a/pushmanager/static/css/base.css
+++ b/pushmanager/static/css/base.css
@@ -717,6 +717,8 @@ ul.tags > .tag-buildbot	{ background: #de9; }
 ul.tags > .tag-pushplans	{ background: #ccf; }
 ul.tags > .tag-git-ok		{ background: #fec; }
 ul.tags > .tag-git-error	{ background: #f00; }
+ul.tags > .tag-conflict-master	{ background: #FF000B; }
+ul.tags > .tag-conflict-pickme	{ background: #FE8D34; }
 ul.tags > .tag-accepting	{ background: #ddf; }
 ul.tags > .tag-live		{ background: #dfd; }
 ul.tags > .tag-search-backend { background: #dcc; }

--- a/pushmanager/static/css/modules/request.css
+++ b/pushmanager/static/css/modules/request.css
@@ -101,6 +101,16 @@ div.request-module {
 	display: block;
 }
 
+.request-conflicts {
+	background: #EE4048;
+	color: #000;
+	font-family: monospace;
+	border: 1px solid #eee;
+	padding: 5px;
+	margin-top: 5px;
+	display: block;
+}
+
 .request-module span.timeago {
 	color: #888;
 }

--- a/pushmanager/templates/modules/request.html
+++ b/pushmanager/templates/modules/request.html
@@ -43,6 +43,11 @@
 	<li><span class="label">Modified</span><span class="value">{{ escape(modify_time) }}</span></li>
 	{% end %}
 
+    {% if request['conflicts'] %}
+    <p>Conflicts:</p>
+    <div class="request-conflicts">{{ request['conflicts'].replace('\n', '<br />') }}</div>
+	{% end %}
+
 	{% if request['description'] %}
 	<p>Description:</p>
 	<div class="request-description">{{ escape(request['description']) }}</div>

--- a/pushmanager/tests/test_core_git.py
+++ b/pushmanager/tests/test_core_git.py
@@ -73,7 +73,7 @@ class CoreGitTest(T.TestCase):
                 return_value=duplicate_req
             ),
         ):
-            pushmanager.core.git.GitQueue.update_request(req['id'])
+            pushmanager.core.git.GitQueue.verify_branch(req['id'])
             yield
 
     def test_get_repository_uri_basic(self):
@@ -105,13 +105,13 @@ class CoreGitTest(T.TestCase):
     def test_process_queue_successful(self):
         """Update the request with its sha"""
         with nested(
-            mock.patch("%s.pushmanager.core.git.GitQueue.update_request_failure" % __name__),
-            mock.patch("%s.pushmanager.core.git.GitQueue.update_request_successful" % __name__),
+            mock.patch("%s.pushmanager.core.git.GitQueue.verify_branch_failure" % __name__),
+            mock.patch("%s.pushmanager.core.git.GitQueue.verify_branch_successful" % __name__),
             self.mocked_update_request(self.fake_request)
         ):
-            # Successful call to update_request should trigger update_request_successful
-            T.assert_equal(pushmanager.core.git.GitQueue.update_request_failure.call_count, 0)
-            T.assert_equal(pushmanager.core.git.GitQueue.update_request_successful.call_count, 1)
+            # Successful call to update_request should trigger verify_branch_successful
+            T.assert_equal(pushmanager.core.git.GitQueue.verify_branch_failure.call_count, 0)
+            T.assert_equal(pushmanager.core.git.GitQueue.verify_branch_successful.call_count, 1)
 
         result = [None]
         def on_db_return(success, db_results):
@@ -127,8 +127,8 @@ class CoreGitTest(T.TestCase):
 
     def test_process_queue_duplicate(self):
         with nested(
-            mock.patch("%s.pushmanager.core.git.GitQueue.update_request_failure" % __name__),
-            mock.patch("%s.pushmanager.core.git.GitQueue.update_request_successful" % __name__),
+            mock.patch("%s.pushmanager.core.git.GitQueue.verify_branch_failure" % __name__),
+            mock.patch("%s.pushmanager.core.git.GitQueue.verify_branch_successful" % __name__),
             # This will fail, stop logging errors
             mock.patch("%s.pushmanager.core.git.logging.error" % __name__),
             mock.patch(
@@ -140,56 +140,56 @@ class CoreGitTest(T.TestCase):
             # GitQueue._get_request_with_sha returning a value means
             # we have a duplicated request. This should trigger a
             # failure
-            T.assert_equal(pushmanager.core.git.GitQueue.update_request_failure.call_count, 1)
-            T.assert_equal(pushmanager.core.git.GitQueue.update_request_successful.call_count, 0)
+            T.assert_equal(pushmanager.core.git.GitQueue.verify_branch_failure.call_count, 1)
+            T.assert_equal(pushmanager.core.git.GitQueue.verify_branch_successful.call_count, 0)
 
             # Match the error message for duplicate revision. error_msg
             # should be the last item of the first call object's *args list
             # (from mock library).
             T.assert_in(
                 "another request with the same revision sha",
-                pushmanager.core.git.GitQueue.update_request_failure.call_args_list[0][0][-1]
+                pushmanager.core.git.GitQueue.verify_branch_failure.call_args_list[0][0][-1]
             )
 
     def test_update_duplicate_request_discarded(self):
         duplicate_req = copy.deepcopy(self.fake_request)
         duplicate_req['state'] = "discarded"
         with nested(
-            mock.patch("%s.pushmanager.core.git.GitQueue.update_request_failure" % __name__),
-            mock.patch("%s.pushmanager.core.git.GitQueue.update_request_successful" % __name__),
+            mock.patch("%s.pushmanager.core.git.GitQueue.verify_branch_failure" % __name__),
+            mock.patch("%s.pushmanager.core.git.GitQueue.verify_branch_successful" % __name__),
             self.mocked_update_request(self.fake_request, duplicate_req)
         ):
-            T.assert_equal(pushmanager.core.git.GitQueue.update_request_failure.call_count, 0)
-            T.assert_equal(pushmanager.core.git.GitQueue.update_request_successful.call_count, 1)
+            T.assert_equal(pushmanager.core.git.GitQueue.verify_branch_failure.call_count, 0)
+            T.assert_equal(pushmanager.core.git.GitQueue.verify_branch_successful.call_count, 1)
 
-    def test_update_request_successful(self):
+    def test_verify_branch_successful(self):
         with nested(
             mock.patch("%s.pushmanager.core.git.MailQueue.enqueue_user_email" % __name__),
             mock.patch("%s.pushmanager.core.git.webhook_req" % __name__)
         ):
-            pushmanager.core.git.GitQueue.update_request_successful(self.fake_request)
+            pushmanager.core.git.GitQueue.verify_branch_successful(self.fake_request)
             T.assert_equal(pushmanager.core.git.MailQueue.enqueue_user_email.call_count, 1)
             T.assert_equal(pushmanager.core.git.webhook_req.call_count, 3)
 
-    def test_update_request_failure(self):
+    def test_verify_branch_failure(self):
         with nested(
             mock.patch("%s.pushmanager.core.git.MailQueue.enqueue_user_email" % __name__),
             mock.patch("%s.pushmanager.core.git.webhook_req" % __name__),
             mock.patch("%s.pushmanager.core.git.logging.error" % __name__),
         ):
-            pushmanager.core.git.GitQueue.update_request_failure(self.fake_request, "fake failure")
+            pushmanager.core.git.GitQueue.verify_branch_failure(self.fake_request, "fake failure")
             T.assert_equal(pushmanager.core.git.MailQueue.enqueue_user_email.call_count, 1)
 
-    def test_update_request_excluded_from_git_verification(self):
+    def test_verify_branch_excluded_from_git_verification(self):
         for tag in pushmanager.core.git.GitQueue.EXCLUDE_FROM_GIT_VERIFICATION:
             req = copy.deepcopy(self.fake_request)
             req['branch'] = None
             req['tags'] = tag
 
             with nested(
-                mock.patch("%s.pushmanager.core.git.GitQueue.update_request_failure" % __name__),
-                mock.patch("%s.pushmanager.core.git.GitQueue.update_request_successful" % __name__),
+                mock.patch("%s.pushmanager.core.git.GitQueue.verify_branch_failure" % __name__),
+                mock.patch("%s.pushmanager.core.git.GitQueue.verify_branch_successful" % __name__),
                 self.mocked_update_request(req)
             ):
-                T.assert_equal(pushmanager.core.git.GitQueue.update_request_failure.call_count, 0)
-                T.assert_equal(pushmanager.core.git.GitQueue.update_request_successful.call_count, 0)
+                T.assert_equal(pushmanager.core.git.GitQueue.verify_branch_failure.call_count, 0)
+                T.assert_equal(pushmanager.core.git.GitQueue.verify_branch_successful.call_count, 0)


### PR DESCRIPTION
Add methods to automatically check for merge conflicts between:
- Pickme'd branches and master
- Pickme'd branches and other pickme'd branches for the same push

Whenever a request is pickmed, a git action is queued that:
- Updates the local copy of master to current head
- Clones or updates the local copy of devs/$dev branch
- Creates a temporary test branch off master
- Attempts to merge the pickmed branch onto the test. If this fails, it marks the pickme as conflict-master
- If it does not conflict with master, it then applies every other pickme in the push on top of the test branch as well, checks if it works, and then reverts. 

All the pickmes that fail to merge are included in a 'conflicts' section on the pickme on pushmanager
