### PR TITLE
Fix submodule conflict checking, missing remotes, repo logic error

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -372,15 +372,15 @@ class GitQueue(object):
 
         # Ensure that the branch we are merging is present
         cls.create_or_update_local_repo(
-            pickme_request['user'],
+            pickme_request['repo'],
             pickme_request['branch'],
             checkout=False
         )
 
         # Locate and merge the branch we are testing
-        summary = "{branch_title}\n\n(Merged from {user}/{branch})".format(
+        summary = "{branch_title}\n\n(Merged from {repo}/{branch})".format(
             branch_title=pickme_request['title'],
-            user=pickme_request['user'],
+            repo=pickme_request['repo'],
             branch=pickme_request['branch']
         )
 
@@ -388,7 +388,7 @@ class GitQueue(object):
             "pull",
             "--no-ff",
             "--no-commit",
-            pickme_request['user'],
+            pickme_request['repo'],
             pickme_request['branch'],
             cwd=master_repo_path)
         pull_command.run()
@@ -519,7 +519,7 @@ class GitQueue(object):
             cls.create_or_update_local_repo(req['repo'], branch=req['branch'])
             ls_remote = GitCommand(
                 'ls-remote', '-h',
-                cls._get_repository_uri(req['user']), req['branch']
+                cls._get_repository_uri(req['repo']), req['branch']
             )
             _, stdout, _ = ls_remote.run()
             stdout = stdout.strip()

--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -105,39 +105,6 @@ def git_reset_to_ref(starting_ref, git_directory):
     ).run()
 
 
-def git_merge_pickme(pickme_request, master_repo_path):
-    """Merges the branch specified by a pickme onto the current branch
-
-    :param pickme_request: Dictionary representing the pickme to merge
-    :param master_repo_path: On-disk path of the git repo to work in
-    """
-
-    # Locate and merge the branch we are testing
-    summary = "{branch_title}\n\n(Merged from {user}/{branch})".format(
-        branch_title=pickme_request['title'],
-        user=pickme_request['user'],
-        branch=pickme_request['branch']
-    )
-
-    pull_command = GitCommand(
-        "pull",
-        "--no-ff",
-        "--no-commit",
-        pickme_request['user'],
-        pickme_request['branch'],
-        cwd=master_repo_path)
-    pull_command.run()
-
-    commit_command = GitCommand(
-        "commit", "-m", summary,
-        "--no-verify", cwd=master_repo_path
-    )
-    commit_command.run()
-
-    # Verify that submodules are OK
-    _stale_submodule_check(master_repo_path)
-
-
 def _stale_submodule_check(cwd):
     """
     Checks that no submodules in the git repository path specified by cwd are
@@ -396,7 +363,48 @@ class GitQueue(object):
         cls.worker_process.start()
 
     @classmethod
-    def create_or_update_local_repo(cls, repo_name, branch):
+    def git_merge_pickme(cls, pickme_request, master_repo_path):
+        """Merges the branch specified by a pickme onto the current branch
+
+        :param pickme_request: Dictionary representing the pickme to merge
+        :param master_repo_path: On-disk path of the git repo to work in
+        """
+
+        # Ensure that the branch we are merging is present
+        cls.create_or_update_local_repo(
+            pickme_request['user'],
+            pickme_request['branch'],
+            checkout=False
+        )
+
+        # Locate and merge the branch we are testing
+        summary = "{branch_title}\n\n(Merged from {user}/{branch})".format(
+            branch_title=pickme_request['title'],
+            user=pickme_request['user'],
+            branch=pickme_request['branch']
+        )
+
+        pull_command = GitCommand(
+            "pull",
+            "--no-ff",
+            "--no-commit",
+            pickme_request['user'],
+            pickme_request['branch'],
+            cwd=master_repo_path)
+        pull_command.run()
+
+        commit_command = GitCommand(
+            "commit", "-m", summary,
+            "--no-verify", cwd=master_repo_path
+        )
+        commit_command.run()
+
+        # Verify that submodules are OK
+        _stale_submodule_check(master_repo_path)
+
+
+    @classmethod
+    def create_or_update_local_repo(cls, repo_name, branch, checkout=True):
         """Clones the main repository if it does not exist.
         If repo_name is not the main repo, add that repo as a remote and fetch
         refs before checking out the specified branch.
@@ -452,22 +460,23 @@ class GitQueue(object):
         fetch_updates = GitCommand('fetch', '--all', '--prune', cwd=repo_path)
         fetch_updates.run()
 
-        # Checkout the branch
-        full_branch = "%s/%s" % (repo_name, branch)
-        checkout_branch = GitCommand('checkout', full_branch, cwd=repo_path)
-        checkout_branch.run()
+        if checkout:
+            # Checkout the branch
+            full_branch = "%s/%s" % (repo_name, branch)
+            checkout_branch = GitCommand('checkout', full_branch, cwd=repo_path)
+            checkout_branch.run()
 
-        # Update submodules
-        sync_submodule = GitCommand(
-            "submodule", "--quiet", "sync",
-            cwd=repo_path
-        )
-        sync_submodule.run()
-        update_submodules = GitCommand(
-            "submodule", "--quiet", "update", "--init",
-            cwd=repo_path
-        )
-        update_submodules.run()
+            # Update submodules
+            sync_submodule = GitCommand(
+                "submodule", "--quiet", "sync",
+                cwd=repo_path
+            )
+            sync_submodule.run()
+            update_submodules = GitCommand(
+                "submodule", "--quiet", "update", "--init",
+                cwd=repo_path
+            )
+            update_submodules.run()
 
     @classmethod
     def _get_local_repository_uri(cls, repository):
@@ -724,7 +733,7 @@ class GitQueue(object):
             try:
                 with git_merge_context_manager(target_branch,
                                                repo_path):
-                    git_merge_pickme(pickme_details, repo_path)
+                    cls.git_merge_pickme(pickme_details, repo_path)
             except GitException, e:
                 conflict_pickmes.append((pickme, e.gitout, e.giterr))
                 # Requeue the conflicting pickme so that it also picks up the
@@ -811,7 +820,7 @@ class GitQueue(object):
             try:
                 with git_merge_context_manager(target_branch, repo_path):
                     # Try to merge the pickme onto master
-                    git_merge_pickme(req, repo_path)
+                    cls.git_merge_pickme(req, repo_path)
 
                     # Check for conflicts with other pickmes
                     return cls._test_pickme_conflict_pickme(

--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -83,13 +83,26 @@ def git_reset_to_ref(starting_ref, git_directory):
     :param starting_ref: Git hash of the commit to roll back to
     """
 
-    reset_command = GitCommand(
+    GitCommand(
         'reset',
         '--hard',
         starting_ref,
         cwd=git_directory
-    )
-    return reset_command.run()
+    ).run()
+
+    GitCommand(
+        'submodule',
+        '--quiet',
+        'sync',
+        cwd=git_directory
+    ).run()
+
+    GitCommand(
+        'submodule',
+        '--quiet',
+        'update',
+        cwd=git_directory
+    ).run()
 
 
 def git_merge_pickme(pickme_request, master_repo_path):

--- a/pushmanager/tests/test_core_git.py
+++ b/pushmanager/tests/test_core_git.py
@@ -403,14 +403,14 @@ class CoreGitTest(T.TestCase):
             f.write('#!/usr/bin/env python\n\nprint("Hallo Welt!")\nPrint("Goodbye!")\n')
         GitCommand('commit', '-a', '-m', 'verpflichten', cwd=repo_path).run()
         GitCommand('checkout', 'master', cwd=repo_path).run()
-        german_req = {'id': 1, 'tags':'git-ok', 'title':'German', 'user':'.', 'branch':'change_german'}
+        german_req = {'id': 1, 'tags':'git-ok', 'title':'German', 'repo':'.', 'branch':'change_german'}
 
         GitCommand('checkout', '-b', 'change_welsh', cwd=repo_path).run()
         with open(os.path.join(repo_path, "code.py"), 'w') as f:
             f.write('#!/usr/bin/env python\n\nprint("Helo Byd!")\nPrint("Goodbye!")\n')
         GitCommand('commit', '-a', '-m', 'ymrwymo', cwd=repo_path).run()
         GitCommand('checkout', 'master', cwd=repo_path).run()
-        welsh_req = {'id': 2, 'tags':'git-ok', 'title':'Welsh', 'user':'.', 'branch':'change_welsh'}
+        welsh_req = {'id': 2, 'tags':'git-ok', 'title':'Welsh', 'repo':'.', 'branch':'change_welsh'}
 
         # Create a test branch for merging
         GitCommand('checkout', '-b', 'test_pcp', cwd=repo_path).run()
@@ -463,7 +463,7 @@ class CoreGitTest(T.TestCase):
         with open(os.path.join(repo_path, "code.py"), 'w') as f:
             f.write('#!/usr/bin/env python\n\nprint("Hallo Welt!")\nPrint("Goodbye!")\n')
         GitCommand('commit', '-a', '-m', 'verpflichten', cwd=repo_path).run()
-        german_req = {'id': 1, 'tags':'git-ok', 'title':'German', 'user':'.', 'branch':'change_german'}
+        german_req = {'id': 1, 'tags':'git-ok', 'title':'German', 'repo':'.', 'branch':'change_german'}
 
         # Back on master, make a conflicting change
         GitCommand('checkout', 'master', cwd=repo_path).run()

--- a/pushmanager/tests/test_core_git.py
+++ b/pushmanager/tests/test_core_git.py
@@ -416,7 +416,9 @@ class CoreGitTest(T.TestCase):
         GitCommand('checkout', '-b', 'test_pcp', cwd=repo_path).run()
 
         # Merge on the first pickme
-        pushmanager.core.git.git_merge_pickme(german_req, repo_path)
+        with mock.patch('pushmanager.core.git.GitQueue.create_or_update_local_repo') as update_repo:
+            pushmanager.core.git.GitQueue.git_merge_pickme(german_req, repo_path)
+            update_repo.assert_called_with('.', 'change_german', checkout=False)
 
         with nested (
                 mock.patch('pushmanager.core.git.GitQueue._get_push_for_request'),


### PR DESCRIPTION
The git reset process called after attempts to merge did not resync submodules, resulting in spurious errors. Add logic to git_reset_to_ref to make it also update submodules.

Conflict detection would also fail when attempting to compare to a branch that was not already known to the local git repo. git_merge_pickme now calls through to add_or_update repo to ensure that the remote to be checked against is present before proceeding. This added logic required moving git_merge_pickme into the GitQueue class.

Finally, a logic error was present in that the submitting user was used as the remote when adding dev branches to git. While these are often the same, repositories can be set differently, which would not be respected by the old code.
