### PR TITLE
Add config option for debugging

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -5,6 +5,7 @@ main_app:
     redir_port: 80
     ssl_certfile: "/path/to/file.pem"
     ssl_keyfile: "/path/to/file.key"
+    debug: False
 
 api_app:
     servername: "pushmanager.example.com"

--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -328,6 +328,8 @@ class GitCommand(subprocess.Popen):
 
     def run(self):
         stdout, stderr = self.communicate()
+        if Settings['main_app']['debug']:
+            logging.error("%r, %r, %r", self.args, stdout, stderr)
         if self.returncode:
             raise GitException(
                 "GitException: git %s " % ' '.join(self.args),


### PR DESCRIPTION
Allow for the inclusion of debug statements, to only be run when pushmanager is in debug mode.

When debugging, log executed git commands and their output.
