### PR TITLE
Release 0.3.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+0.3.2   2014-08-15
+
+ PERFORMANCE TWEAKS
+
+ * Only requeue existing conflicted pickme's when a pickme
+   is removed. (rschlaikjer, #79, #80)
+
 0.3.1   2014-08-14
 
  BUG FIXES

--- a/pushmanager/__about__.py
+++ b/pushmanager/__about__.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 3, 1)
+__version_info__ = (0, 3, 2)
 __version__ = '%d.%d.%d' % __version_info__


### PR DESCRIPTION
 PERFORMANCE TWEAKS
- Only requeue existing conflicted pickme's when a pickme
  is removed. (rschlaikjer, #79, #80)
