### PR TITLE
Fetch non-ff changes

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -459,32 +459,27 @@ class GitQueue(object):
             clone_repo = GitCommand(*clone_args)
             clone_repo.run()
 
-        # If we are dealing with a dev repo, make sure it is added as a remote
-        dev_repo_uri = cls._get_repository_uri(repo_name)
-        add_remote = GitCommand(
-            'remote', 'add', repo_name, dev_repo_uri,
-            cwd=repo_path
-        )
-        try:
-            add_remote.run()
-            # If we had to add a new remote, we should fetch it.
-            fetch = True
-        except GitException, e:
-            # If the remote already exists, git will return err 128
-            if e.gitret is 128:
-                pass
-            else:
-                raise e
-
         if fetch:
+            # If we are dealing with a dev repo, make sure it is added as a remote
+            dev_repo_uri = cls._get_repository_uri(repo_name)
+            add_remote = GitCommand(
+                'remote', 'add', repo_name, dev_repo_uri,
+                cwd=repo_path
+            )
+            try:
+                add_remote.run()
+            except GitException, e:
+                # If the remote already exists, git will return err 128
+                if e.gitret is 128:
+                    pass
+                else:
+                    raise e
+
             # Fetch the specified branch from the repo
-            remote_path = '{branch}:refs/remotes/{repo}/{branch}'.format(
+            remote_path = '+refs/heads/{branch}:refs/remotes/{repo}/{branch}'.format(
                 branch=branch,
                 repo=repo_name
             )
-
-            if branch is 'master':
-                remote_path = branch
 
             fetch_updates = GitCommand(
                 'fetch',

--- a/pushmanager/tests/test_core_git.py
+++ b/pushmanager/tests/test_core_git.py
@@ -312,13 +312,13 @@ class CoreGitTest(T.TestCase):
     def test_create_or_update_local_repo_master(self):
         expected_cwd = '/place/to/store/on-disk/git/repos/main-repository'
         with mock.patch('pushmanager.core.git.GitCommand') as GC:
-            pushmanager.core.git.GitQueue.create_or_update_local_repo(Settings['git']['main_repository'], 'test_branch')
+            pushmanager.core.git.GitQueue.create_or_update_local_repo(Settings['git']['main_repository'], 'test_branch', fetch=True)
             calls = [
                 mock.call('clone', 'git://git.example.com/main-repository', expected_cwd),
                 mock.call().run(),
                 mock.call('remote', 'add', 'origin', 'git://git.example.com/main-repository', cwd=expected_cwd),
                 mock.call().run(),
-                mock.call('fetch', '--prune', 'origin', 'test_branch:refs/remotes/origin/test_branch', cwd=expected_cwd),
+                mock.call('fetch', '--prune', 'origin', '+refs/heads/test_branch:refs/remotes/origin/test_branch', cwd=expected_cwd),
                 mock.call().run(),
                 mock.call('reset', '--hard', 'HEAD', cwd='/place/to/store/on-disk/git/repos/main-repository'),
                 mock.call().run(),
@@ -336,13 +336,13 @@ class CoreGitTest(T.TestCase):
     def test_create_or_update_local_repo_dev(self):
         expected_cwd = '/place/to/store/on-disk/git/repos/main-repository'
         with mock.patch('pushmanager.core.git.GitCommand') as GC:
-            pushmanager.core.git.GitQueue.create_or_update_local_repo('some_dev_name', 'test_branch')
+            pushmanager.core.git.GitQueue.create_or_update_local_repo('some_dev_name', 'test_branch', fetch=True)
             calls = [
                 mock.call('clone', 'git://git.example.com/main-repository', expected_cwd),
                 mock.call().run(),
                 mock.call('remote', 'add', 'some_dev_name', 'git://git.example.com/devs/some_dev_name', cwd=expected_cwd),
                 mock.call().run(),
-                mock.call('fetch', '--prune', 'some_dev_name', 'test_branch:refs/remotes/some_dev_name/test_branch', cwd=expected_cwd),
+                mock.call('fetch', '--prune', 'some_dev_name', '+refs/heads/test_branch:refs/remotes/some_dev_name/test_branch', cwd=expected_cwd),
                 mock.call().run(),
                 mock.call('reset', '--hard', 'HEAD', cwd='/place/to/store/on-disk/git/repos/main-repository'),
                 mock.call().run(),
@@ -374,13 +374,13 @@ class CoreGitTest(T.TestCase):
         expected_cwd = '/place/to/store/on-disk/git/repos/main-repository'
         with mock.patch.dict(Settings, test_settings, clear=True):
             with mock.patch('pushmanager.core.git.GitCommand') as GC:
-                pushmanager.core.git.GitQueue.create_or_update_local_repo('some_dev_name', 'test_branch')
+                pushmanager.core.git.GitQueue.create_or_update_local_repo('some_dev_name', 'test_branch', fetch=True)
                 calls = [
                     mock.call('clone', 'git://git.example.com/main-repository', '--reference', '/', expected_cwd),
                     mock.call().run(),
                     mock.call('remote', 'add', 'some_dev_name', 'git://git.example.com/devs/some_dev_name', cwd=expected_cwd),
                     mock.call().run(),
-                    mock.call('fetch', '--prune', 'some_dev_name', 'test_branch:refs/remotes/some_dev_name/test_branch', cwd=expected_cwd),
+                    mock.call('fetch', '--prune', 'some_dev_name', '+refs/heads/test_branch:refs/remotes/some_dev_name/test_branch', cwd=expected_cwd),
                     mock.call().run(),
                     mock.call('reset', '--hard', 'HEAD', cwd='/place/to/store/on-disk/git/repos/main-repository'),
                     mock.call().run(),


### PR DESCRIPTION
Add a + to refspecs so that pushmanager will fetch the lastest branch, regardless of whether it is a fast forward.

https://www.kernel.org/pub/software/scm/git/docs/git-fetch.html

Also move remote adding into the fetch subsection.
