### PR TITLE
Check if pickmes are already merged into master, and if so ignore them

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -352,6 +352,8 @@ class GitQueue(object):
     request_queue = None
     worker_process = None
 
+    shas_in_master = {}
+
     EXCLUDE_FROM_GIT_VERIFICATION = Settings['git']['exclude_from_verification']
 
     @classmethod
@@ -718,6 +720,36 @@ class GitQueue(object):
         return updated_request
 
     @classmethod
+    def _sha_exists_in_master(cls, sha):
+        """Check if a given SHA is included in master
+        Memoize shas that are, so that we can avoid expensive rev-lists later.
+        We can't cache shas that are not in master, since we won't know when they get merged.
+        """
+
+        # Dirty cache expiry mechanism, but better than constantly
+        # accumulating SHAs in memory
+        if len(cls.shas_in_master) > 1000:
+            cls.shas_in_master = {}
+
+        if sha in cls.shas_in_master:
+            logging.error("Found sha in cache")
+            return True
+
+        repo_path = cls._get_local_repository_uri(
+            Settings['git']['main_repository']
+        )
+
+        _, merge_base, _ = GitCommand('merge-base', 'origin/master', sha, cwd=repo_path).run()
+
+        merge_base = merge_base.strip()
+
+        if sha == merge_base:
+            cls.shas_in_master[sha] = True
+            return True
+        else:
+            return False
+
+    @classmethod
     def _test_pickme_conflict_pickme(cls, req, target_branch,
                                      repo_path, requeue):
         """Test for any pickmes that are broken by pickme'd request req
@@ -755,6 +787,13 @@ class GitQueue(object):
                     pickme
                 )
                 continue
+
+            # Don't check against pickmes that are already in master, as
+            # it would throw 'nothing to commit' errors
+            sha = cls._get_branch_sha_from_repo(req)
+            if sha is None or cls._sha_exists_in_master(sha):
+                continue
+
 
             # Don't bother trying to compare against pickmes that
             # break master, as they will conflict by default
@@ -926,6 +965,15 @@ class GitQueue(object):
             push_id=push_id,
             pickme_id=request_id
         )
+
+        # Check that the branch is still reachable
+        sha = cls._get_branch_sha_from_repo(req)
+        if sha is None:
+            return
+
+        # Check if the pickme has already been merged into master
+        if cls._sha_exists_in_master(sha):
+            return
 
         # Clear the pickme's conflict info
         cls._clear_pickme_conflict_details(req)

--- a/pushmanager/tests/test_core_git.py
+++ b/pushmanager/tests/test_core_git.py
@@ -445,14 +445,14 @@ class CoreGitTest(T.TestCase):
             f.write('#!/usr/bin/env python\n\nprint("Hallo Welt!")\nPrint("Goodbye!")\n')
         GitCommand('commit', '-a', '-m', 'verpflichten', cwd=repo_path).run()
         GitCommand('checkout', 'master', cwd=repo_path).run()
-        german_req = {'id': 1, 'tags':'git-ok', 'title':'German', 'repo':'.', 'branch':'change_german'}
+        german_req = {'id': 1, 'user':'test', 'tags':'git-ok', 'title':'German', 'repo':'.', 'branch':'change_german'}
 
         GitCommand('checkout', '-b', 'change_welsh', cwd=repo_path).run()
         with open(os.path.join(repo_path, "code.py"), 'w') as f:
             f.write('#!/usr/bin/env python\n\nprint("Helo Byd!")\nPrint("Goodbye!")\n')
         GitCommand('commit', '-a', '-m', 'ymrwymo', cwd=repo_path).run()
         GitCommand('checkout', 'master', cwd=repo_path).run()
-        welsh_req = {'id': 2, 'tags':'git-ok', 'title':'Welsh', 'repo':'.', 'branch':'change_welsh'}
+        welsh_req = {'id': 2, 'user': 'test', 'user': 'test', 'tags':'git-ok', 'title':'Welsh', 'repo':'.', 'branch':'change_welsh'}
 
         # Create a test branch for merging
         GitCommand('checkout', '-b', 'test_pcp', cwd=repo_path).run()
@@ -466,12 +466,16 @@ class CoreGitTest(T.TestCase):
                 mock.patch('pushmanager.core.git.GitQueue._get_push_for_request'),
                 mock.patch('pushmanager.core.git.GitQueue._get_request_ids_in_push'),
                 mock.patch('pushmanager.core.git.GitQueue._get_request'),
+                mock.patch('pushmanager.core.git.GitQueue._get_branch_sha_from_repo'),
+                mock.patch('pushmanager.core.git.GitQueue._sha_exists_in_master'),
                 mock.patch('pushmanager.core.git.GitQueue._update_request'),
                 mock.patch.dict(Settings, test_settings, clear=True)
-        ) as (p_for_r, r_in_p, get_req, update_req, _) :
+        ) as (p_for_r, r_in_p, get_req, get_sha, sha_exists, update_req, _) :
             p_for_r.return_value = {'push': 1}
             r_in_p.return_value = [1, 2]
             get_req.return_value = welsh_req
+            get_sha.return_value = "0"*40
+            sha_exists.return_value = False
             update_req.return_value = german_req
             conflict, _ = pushmanager.core.git.GitQueue._test_pickme_conflict_pickme(
                 german_req,


### PR DESCRIPTION
Checking pickmes that are already merged into master would result in a conflict-master tag, since there would be nothing to commit. 

Before conflict checking a pickme against master, check if it is in master. If so, break.
Before checking a pickme against a second pickme, check the second pickme is not in master.

To hopefully avoid running rev-list more than is necessary, do very basic caching of SHAs that are known to be in master.
