### PR TITLE
Add rerun detection button

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -1199,7 +1199,7 @@ class GitQueue(object):
         for req in request_details:
             GitQueue.enqueue_request(
                 GitTaskAction.TEST_PICKME_CONFLICT,
-                pickme_id,
+                req['id'],
                 requeue=False
             )
 

--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -279,6 +279,7 @@ class GitTaskAction(object):
     VERIFY_BRANCH = 1
     TEST_PICKME_CONFLICT = 2
     TEST_ALL_PICKMES = 3
+    TEST_CONFLICTING_PICKMES = 4
 
 
 class GitQueueTask(object):
@@ -1183,15 +1184,24 @@ class GitQueue(object):
         MailQueue.enqueue_user_email([user_to_notify], msg, subject)
 
     @classmethod
-    def requeue_pickmes_with_conflicts(cls, push_id):
+    def requeue_pickmes_for_push(cls, push_id, conflicting_only=False):
+        request_details = []
         for pickme_id in cls._get_request_ids_in_push(push_id):
-            req = cls._get_request(pickme_id)
-            if req and req['tags'] and 'conflict-pickme' in req['tags']:
-                GitQueue.enqueue_request(
-                    GitTaskAction.TEST_PICKME_CONFLICT,
-                    pickme_id,
-                    requeue=False
-                )
+            request_details.append(cls._get_request(pickme_id))
+
+        if conflicting_only:
+            request_details = [
+                req for req in request_details
+                if req and req['tags']
+                and 'conflict-pickme' in req['tags']
+            ]
+
+        for req in request_details:
+            GitQueue.enqueue_request(
+                GitTaskAction.TEST_PICKME_CONFLICT,
+                pickme_id,
+                requeue=False
+            )
 
     @classmethod
     def process_queue(cls):
@@ -1210,8 +1220,10 @@ class GitQueue(object):
                     cls.verify_branch(task.request_id)
                 elif task.task_type is GitTaskAction.TEST_PICKME_CONFLICT:
                     cls.test_pickme_conflicts(task.request_id, **task.kwargs)
+                elif task.task_type is GitTaskAction.TEST_CONFLICTING_PICKMES:
+                    cls.requeue_pickmes_for_push(task.request_id, conflicting_only=True)
                 elif task.task_type is GitTaskAction.TEST_ALL_PICKMES:
-                    cls.requeue_pickmes_with_conflicts(task.request_id)
+                    cls.requeue_pickmes_for_push(task.request_id)
                 else:
                     logging.error(
                         "GitQueue encountered unknown task type %d",

--- a/pushmanager/pushmanager_main.py
+++ b/pushmanager/pushmanager_main.py
@@ -25,6 +25,7 @@ from pushmanager.servlets.blesspush import BlessPushServlet
 from pushmanager.servlets.checklist import ChecklistServlet
 from pushmanager.servlets.checklist import ChecklistToggleServlet
 from pushmanager.servlets.commentrequest import CommentRequestServlet
+from pushmanager.servlets.conflictcheck import ConflictCheckServlet
 from pushmanager.servlets.delayrequest import DelayRequestServlet
 from pushmanager.servlets.deploypush import DeployPushServlet
 from pushmanager.servlets.discardpush import DiscardPushServlet
@@ -64,6 +65,7 @@ def get_url_specs():
     for servlet in (APIServlet,
                     ChecklistServlet,
                     ChecklistToggleServlet,
+                    ConflictCheckServlet,
                     RequestServlet,
                     RequestsServlet,
                     NewRequestServlet,

--- a/pushmanager/servlets/conflictcheck.py
+++ b/pushmanager/servlets/conflictcheck.py
@@ -1,0 +1,17 @@
+import pushmanager.core.util
+from pushmanager.core.git import GitQueue
+from pushmanager.core.git import GitTaskAction
+from pushmanager.core.requesthandler import RequestHandler
+
+
+class ConflictCheckServlet(RequestHandler):
+
+    def _arg(self, key):
+        return pushmanager.core.util.get_str_arg(self.request, key, '')
+
+    def post(self):
+        if not self.current_user:
+            return self.send_error(403)
+        self.pushid = pushmanager.core.util.get_int_arg(self.request, 'id')
+        GitQueue.enqueue_request(GitTaskAction.TEST_ALL_PICKMES, self.pushid)
+        self.redirect("/push?id=%d" % self.pushid)

--- a/pushmanager/servlets/pickmerequest.py
+++ b/pushmanager/servlets/pickmerequest.py
@@ -90,4 +90,6 @@ class UnpickMeRequestServlet(RequestHandler):
 
     def on_db_complete(self, success, db_results):
         self.check_db_results(success, db_results)
-        GitQueue.enqueue_request(GitTaskAction.TEST_ALL_PICKMES, self.pushid)
+        # Re-check pickmes that are marked as conflicting, in case this was the pickme
+        # that they conflicted against.
+        GitQueue.enqueue_request(GitTaskAction.TEST_CONFLICTING_PICKMES, self.pushid)

--- a/pushmanager/static/js/push.js
+++ b/pushmanager/static/js/push.js
@@ -314,6 +314,14 @@ $(function() {
         $('#push-info-form').hide();
     });
 
+    $('#rerun-conflict-check').click(function() {
+        $('#confirm-conflict-check').show();
+    });
+
+    $('#cancel-conflict-check').click(function() {
+        $('#confirm-conflict-check').hide();
+    });
+
     $('#discard-push').click(function() {
         PushManager.run_command_dialog("git push --delete canon " + $('#push-info').attr('branch'), function() {
             // Go ahead and discard it.

--- a/pushmanager/templates/confirm-conflict-check.html
+++ b/pushmanager/templates/confirm-conflict-check.html
@@ -1,0 +1,15 @@
+<form id="confirm-conflict-check" class="popup-form" action="/conflictcheck" method="POST">
+<div class="form-wrapper">
+
+    <h2>Check Push for Conflicts</h2>
+
+    <input type="hidden" name="id" value="{{ int(push_info['id']) }}" />
+
+    Re-run conflict detection on all requests pickme'd for this push?
+
+    <div class="buttons">
+        <input type="submit" id="check-conflicts" name="check-conflicts" value="Run" />
+        <input type="reset" id="cancel-conflict-check" name="cancel-conflict-check" value="Don't Run" />
+    </div>
+</div>
+</form>

--- a/pushmanager/templates/push-button-bar.html
+++ b/pushmanager/templates/push-button-bar.html
@@ -23,6 +23,7 @@
 		&mdash;
 		<li><button id="message-all">Message All</button></li>
 		<li><button id="show-checklist">Push Checklist</button></li>
+		<li><button id="rerun-conflict-check">Rerun Conflict Detection</button></li>
 		{% end %}
 	{% else %}
 		{% if push_info['state'] == 'accepting' %}

--- a/pushmanager/templates/push.html
+++ b/pushmanager/templates/push.html
@@ -6,6 +6,9 @@
 <div id="form-anchor">&nbsp;
 	{% include 'edit-push.html' %}
 </div>
+<div id="form-anchor">&nbsp;
+	{% include 'confirm-conflict-check.html' %}
+</div>
 <!-- ========= PUSH INFO ========== -->
 {% include 'push-info.html' %}
 <!-- ========= BUTTON BAR ========== -->

--- a/pushmanager/tests/test_core_git.py
+++ b/pushmanager/tests/test_core_git.py
@@ -566,9 +566,40 @@ class CoreGitTest(T.TestCase):
 
             get_req.side_effect = update_get_req
 
-            pushmanager.core.git.GitQueue.requeue_pickmes_with_conflicts(1)
+            pushmanager.core.git.GitQueue.requeue_pickmes_for_push(1, conflicting_only=True)
 
-            calls = [mock.call(GitTaskAction.TEST_PICKME_CONFLICT, 0, requeue=False)]
+            calls = [mock.call(GitTaskAction.TEST_PICKME_CONFLICT, 1, requeue=False)]
+
+            enqueue_req.assert_has_calls(calls)
+
+    def test_requeue_all_pickmes(self):
+        with nested(
+            mock.patch.object(GitQueue, '_get_request_ids_in_push'),
+            mock.patch.object(GitQueue, '_get_request'),
+            mock.patch.object(GitQueue, 'enqueue_request')
+        ) as (ids_in_push, get_req, enqueue_req):
+
+            reqs = [
+                {'id': 1, 'tags': 'git-ok,conflict-pickme'},
+                {'id': 2, 'tags': 'git-ok,conflict-master'},
+                {'id': 3, 'tags': 'git-ok,feature'}
+            ]
+
+            ids_in_push.return_value = [0, 1, 2]
+            get_req.return_value = reqs[0]
+
+            def update_get_req(i):
+                return reqs[i]
+
+            get_req.side_effect = update_get_req
+
+            pushmanager.core.git.GitQueue.requeue_pickmes_for_push(1)
+
+            calls = [
+                mock.call(GitTaskAction.TEST_PICKME_CONFLICT, 1, requeue=False),
+                mock.call(GitTaskAction.TEST_PICKME_CONFLICT, 2, requeue=False),
+                mock.call(GitTaskAction.TEST_PICKME_CONFLICT, 3, requeue=False),
+            ]
 
             enqueue_req.assert_has_calls(calls)
 

--- a/pushmanager/tests/test_template_push.py
+++ b/pushmanager/tests/test_template_push.py
@@ -400,7 +400,7 @@ class PushTemplateTest(TemplateTestCase):
             'discard-push', 'add-selected-requests',
             'remove-selected-requests', 'rebuild-deploy-branch',
             'deploy-to-stage-step0', 'deploy-to-prod', 'merge-to-master',
-            'message-all', 'show-checklist']
+            'message-all', 'show-checklist', 'rerun-conflict-check']
 
     def test_push_buttons_random_user(self):
         with self.no_ui_modules():


### PR DESCRIPTION
Add a button to the pushmaster UI for pushes that will kick off conflict detection again for all the pickmes in the push. This would be useful for rechecking the push against a previous push that has just certed.
