### PR TITLE
Release 0.3.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+0.3.3   2014-08-08
+
+ BUG FIXES
+
+ * Don't run merge detection on merged requests (rschlaikjer, #84, #91)
+ * Fetch non-ff branches (rschlaikjer, #85, #90)
+
+ IMPROVEMENTS
+
+ * Manually rerun merge detection (rschlaikjer, #86, #92)
+
+ PERFORMANCE TWEAKS
+
+ * Separate git sha retrieval from git merge conflict detection.
+   (rschlaikjer, #82, #83)
+
 0.3.2   2014-08-15
 
  PERFORMANCE TWEAKS

--- a/pushmanager/__about__.py
+++ b/pushmanager/__about__.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 3, 2)
+__version_info__ = (0, 3, 3)
 __version__ = '%d.%d.%d' % __version_info__


### PR DESCRIPTION
 BUG FIXES
- Don't run merge detection on merged requests (rschlaikjer, #84, #91)
- Fetch non-ff branches (rschlaikjer, #85, #90)
  
  IMPROVEMENTS
- Manually rerun merge detection (rschlaikjer, #86, #92)
  
  PERFORMANCE TWEAKS
- Separate git sha retrieval from git merge conflict detection.
  (rschlaikjer, #82, #83)
