### PR TITLE
Handle 'no such commit' merge-base error, incorrect request reference, overly verbose logline

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -743,7 +743,12 @@ class GitQueue(object):
             Settings['git']['main_repository']
         )
 
-        _, merge_base, _ = GitCommand('merge-base', 'origin/master', sha, cwd=repo_path).run()
+        try:
+            _, merge_base, _ = GitCommand('merge-base', 'origin/master', sha, cwd=repo_path).run()
+        except GitException:
+            # If the hash is entirely unknown, Git will throw an error
+            # fatal: Not a valid commit name <sha>.
+            return False
 
         merge_base = merge_base.strip()
 

--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -799,7 +799,7 @@ class GitQueue(object):
 
             # Don't check against pickmes that are already in master, as
             # it would throw 'nothing to commit' errors
-            sha = cls._get_branch_sha_from_repo(req)
+            sha = cls._get_branch_sha_from_repo(pickme_details)
             if sha is None or cls._sha_exists_in_master(sha):
                 continue
 

--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -737,7 +737,6 @@ class GitQueue(object):
             cls.shas_in_master = {}
 
         if sha in cls.shas_in_master:
-            logging.error("Found sha in cache")
             return True
 
         repo_path = cls._get_local_repository_uri(


### PR DESCRIPTION
We needed to verify whether the current pickme we are comparing our base pickme
against exists in master, but were just checking if the base pickme is in master.

Remove an overly verbose debugging logline.

When a commit is entirely unknown to git, merge-base will throw an error. Treat this as the sha not being in master.
