### PR TITLE
Release 0.3.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+0.3.4   2014-08-08
+
+ BUG FIXES
+
+ * When checking if a pickme has already been merged, use
+   the pickme's id. (rschlaikjer, #94)
+
 0.3.3   2014-08-08
 
  BUG FIXES

--- a/pushmanager/__about__.py
+++ b/pushmanager/__about__.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 3, 3)
+__version_info__ = (0, 3, 4)
 __version__ = '%d.%d.%d' % __version_info__


### PR DESCRIPTION
 BUG FIXES
- When checking if a pickme has already been merged, use
  the pickme's id. (rschlaikjer, #94)
