### PR TITLE
Fetch the pickme branch being checked

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -797,6 +797,14 @@ class GitQueue(object):
                 )
                 continue
 
+            # Ensure we have a copy of the pickme we are comparing against
+            cls.create_or_update_local_repo(
+                pickme_details['repo'],
+                branch=pickme_details['branch'],
+                fetch=True,
+                checkout=False
+            )
+
             # Don't check against pickmes that are already in master, as
             # it would throw 'nothing to commit' errors
             sha = cls._get_branch_sha_from_repo(pickme_details)
@@ -891,6 +899,14 @@ class GitQueue(object):
         :param target_branch: The name of the test branch to use for testing
         :param repo_path: The location of the repository we are working in
         """
+
+        # Ensure we have a copy of the pickme branch
+        cls.create_or_update_local_repo(
+            req['repo'],
+            branch=req['branch'],
+            fetch=True,
+            checkout=False
+        )
 
         # Create a test branch following master
         with git_branch_context_manager(target_branch, repo_path):

--- a/pushmanager/tests/test_core_git.py
+++ b/pushmanager/tests/test_core_git.py
@@ -453,9 +453,10 @@ class CoreGitTest(T.TestCase):
                 mock.patch('pushmanager.core.git.GitQueue._get_request'),
                 mock.patch('pushmanager.core.git.GitQueue._get_branch_sha_from_repo'),
                 mock.patch('pushmanager.core.git.GitQueue._sha_exists_in_master'),
+                mock.patch('pushmanager.core.git.GitQueue.create_or_update_local_repo'),
                 mock.patch('pushmanager.core.git.GitQueue._update_request'),
                 mock.patch.dict(Settings, test_settings, clear=True)
-        ) as (p_for_r, r_in_p, get_req, get_sha, sha_exists, update_req, _) :
+        ) as (p_for_r, r_in_p, get_req, get_sha, sha_exists, _, update_req, _) :
             p_for_r.return_value = {'push': 1}
             r_in_p.return_value = [1, 2]
             get_req.return_value = welsh_req
@@ -521,8 +522,9 @@ class CoreGitTest(T.TestCase):
                     'pushmanager.core.git.git_branch_context_manager',
                     NoRemoteBranchContextManager
                 ),
+                mock.patch('pushmanager.core.git.GitQueue.create_or_update_local_repo'),
                 mock.patch.dict(Settings, test_settings, clear=True)
-        ) as (update_req, _, _) :
+        ) as (update_req, _, _, _) :
             conflict, _ = pushmanager.core.git.GitQueue._test_pickme_conflict_master(
                 german_req,
                 "test_pcm",


### PR DESCRIPTION
Now that git SHA verification is ls-remote based and not fetch based, branches
that are pickme'd are not in the local git repository. This causes problems for
merges.
