### PR TITLE
Track queue worker pids and kill on exit

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -369,8 +369,9 @@ class GitQueue(object):
 
     @classmethod
     def start_worker(cls):
+        worker_pids = []
         if cls.conflict_worker_process is not None and cls.sha_worker_process is not None:
-            return
+            return worker_pids
 
         cls.conflict_queue = JoinableQueue()
         cls.sha_queue = JoinableQueue()
@@ -385,10 +386,14 @@ class GitQueue(object):
             worker_thread.daemon = True
             worker_thread.start()
             cls.conflict_workers.append(worker_thread)
+            worker_pids.append(worker_thread.pid)
 
         cls.sha_worker_process = Process(target=cls.process_sha_queue, name='git-sha-queue')
         cls.sha_worker_process.daemon = True
         cls.sha_worker_process.start()
+        worker_pids.append(cls.sha_worker_process.pid)
+
+        return worker_pids
 
     @classmethod
     def git_merge_pickme(cls, worker_id, pickme_request, master_repo_path):

--- a/pushmanager/core/mail.py
+++ b/pushmanager/core/mail.py
@@ -17,11 +17,12 @@ class MailQueue(object):
     @classmethod
     def start_worker(cls):
         if cls.worker_process is not None:
-            return
+            return []
         cls.message_queue = JoinableQueue()
         cls.worker_process = Process(target=cls.process_queue, name='mail-queue')
         cls.worker_process.daemon = True
         cls.worker_process.start()
+        return [cls.worker_process.pid]
 
     @classmethod
     def process_queue(cls):

--- a/pushmanager/core/pid.py
+++ b/pushmanager/core/pid.py
@@ -47,9 +47,10 @@ def check(path):
         else:
             raise
 
-def write(path, append=False):
+def write(path, append=False, pid=None):
     try:
-        pid = os.getpid()
+        if pid is None:
+            pid = os.getpid()
         if append:
             pidfile = open(path, 'a+b')
         else:

--- a/pushmanager/core/rb.py
+++ b/pushmanager/core/rb.py
@@ -18,11 +18,12 @@ class RBQueue(object):
     @classmethod
     def start_worker(cls):
         if cls.worker_process is not None:
-            return
+            return []
         cls.review_queue = JoinableQueue()
         cls.worker_process = Process(target=cls.process_queue, name='rb-queue')
         cls.worker_process.daemon = True
         cls.worker_process.start()
+        return [cls.worker_process.pid]
 
     @classmethod
     def process_queue(cls):

--- a/pushmanager/core/xmppclient.py
+++ b/pushmanager/core/xmppclient.py
@@ -20,11 +20,12 @@ class XMPPQueue(object):
     @classmethod
     def start_worker(cls):
         if cls.worker_process is not None:
-            return
+            return []
         cls.message_queue = JoinableQueue()
         cls.worker_process = Process(target=cls.process_queue, name='xmpp-queue')
         cls.worker_process.daemon = True
         cls.worker_process.start()
+        return [cls.worker_process.pid]
 
     @classmethod
     def _retry_message(cls, msg):


### PR DESCRIPTION
When spawning the queue worker processes, keep a list of their process IDs
and write them to the pidfile.

When exiting, send SIGKILL to the queue worker processes.
