### PR TITLE
Multithread conflict detection

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -79,6 +79,7 @@ git:
     local_repo_path: "/place/to/store/on-disk/git/repos/"
     local_mirror: "/rererence/repository/for/main_repository"
     use_local_mirror: False
+    conflict-threads: 1
 
     # A background worker tries to verify the given branch in a push
     # request by checking the SHA of the branch in the repository and


### PR DESCRIPTION
Allow for the option of using multiple threads to check for conflicts.

This requires that each thread have it's own copy of the repository, so there is
a space:performance tradeoff here.

It is also recommended to store the repositories on different physical volumes
and symlink them into the local repo directory to avoid disk thrashing.
