### PR TITLE
Skip requests that are not pickmed when processed

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -813,6 +813,9 @@ class GitQueue(object):
                 )
                 continue
 
+            if 'state' not in pickme_details or pickme_details['state'] is not 'pickme':
+                continue
+
             # Ensure we have a copy of the pickme we are comparing against
             cls.create_or_update_local_repo(
                 worker_id,
@@ -980,6 +983,9 @@ class GitQueue(object):
                 "Tried to test conflicts for invalid request id %s",
                 request_id
             )
+            return
+
+        if 'state' not in req or req['state'] is not 'pickme':
             return
 
         push = cls._get_push_for_request(request_id)


### PR DESCRIPTION
Due to processing delays, by the time some pickmes are processed they can have
been depickmed, merged into the deploy branch or otherwise no longer in the
pickme state.

To avoid extra work, only process pickmes that are pickmes at the time of the
checks.
