### PR TITLE
Replaced the trac specific ticket link with a general link.

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -65,8 +65,9 @@ reviewboard:
 buildbot:
     servername: buildbot.mydomain.com
 
-trac:
-    servername: trac.example.com
+# Format: http://server:port/path/%TICKET%
+# The string %TICKET% will be replaced by the ticket id
+ticket_tracker_url_format: "http://server:port/path/%TICKET%"
 
 git:
     scheme: "git"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -65,7 +65,6 @@ reviewboard:
 buildbot:
     servername: buildbot.mydomain.com
 
-# Format: http://server:port/path/%TICKET%
 # The string %TICKET% will be replaced by the ticket id
 ticket_tracker_url_format: "http://server:port/path/%TICKET%"
 

--- a/pushmanager/core/settings.py
+++ b/pushmanager/core/settings.py
@@ -33,9 +33,7 @@ JSSettings = {
     'reviewboard': {
         'servername': None,
     },
-    'trac': {
-        'servername': None,
-    },
+    'ticket_tracker_url_format': None,
     'git': {
         'main_repository': None,
     },

--- a/pushmanager/templates/create_request_bookmarklet.js
+++ b/pushmanager/templates/create_request_bookmarklet.js
@@ -2,7 +2,7 @@
     Settings = {{ JSSettings_json }};
 
     var ticketNumberToURL = function(bug) {
-        return 'https://' + Settings['trac']['servername'] + '/ticket/' + bug.match(/\d+/)[0];
+        return Settings['ticket_tracker_url_format'].replace("%TICKET%", bug);
     };
 
     var summary = $('#summary').text();

--- a/pushmanager/tests/test_bookmarklet.py
+++ b/pushmanager/tests/test_bookmarklet.py
@@ -30,6 +30,7 @@ class BookmarkletTest(T.TestCase, AsyncTestCase):
             T.assert_equal(response.error, None)
             T.assert_in("ticketNumberToURL", response.body)
             T.assert_in("codeReview", response.body)
+            T.assert_in("%TICKET%", response.body)
 
 
     def test_check_sites_bookmarklet(self):


### PR DESCRIPTION
Bug description: when you use the pushmanager create bookmarklet on a review
boad CR, jira tickets are not parsed correctly. They are thought to be trac
tickets, and an incorrect trac link is generated in the PR comments.

Ref: (PUSHMGR-63) Pushmanager Create does not parse jira issues correctly
