### PR TITLE
Split pushmanager messages across multiple lines to avoid max char limit

### DIFF
--- a/pushmanager/servlets/msg.py
+++ b/pushmanager/servlets/msg.py
@@ -37,11 +37,11 @@ class MsgServlet(RequestHandler):
         # divide people into groups, each group has 5 persons.
         groups = [people[i:i+5] for i in range(0, len(people), 5)]
 
-        for group in groups:
-            irc_message = u'[[pushmaster {0}]] {1}{2}'.format(
-                self.current_user,
-                ', '.join(group) + ': ',
-                message,
+        for i, group in enumerate(groups):
+            irc_message = u'{0} {1}{2}'.format(
+                '[[pushmaster %s]]' % self.current_user if not i else '',
+                ', '.join(group),
+                ': ' + message if i == len(groups) - 1 else '',
             )
             subprocess.call([
                 '/nail/sys/bin/nodebot',

--- a/pushmanager/servlets/msg.py
+++ b/pushmanager/servlets/msg.py
@@ -19,15 +19,34 @@ class MsgServlet(RequestHandler):
             pushmaster=self.current_user
         )
 
-        irc_message = u'[[pushmaster {0}]] {1}{2}'.format(
-            self.current_user,
-            ', '.join(people) + ': ' if people else '',
-            message,
-        )
-        subprocess.call([
+        if not people:
+            irc_message = u'[[pushmaster {0}]] {1}'.format(
+                self.current_user,
+                message,
+            )
+
+            subprocess.call([
                 '/nail/sys/bin/nodebot',
                 '-i',
                 irc_nick,
                 Settings['irc']['channel'],
                 irc_message
-        ])
+            ])
+            return
+
+        # divide people into groups, each group has 5 persons.
+        groups = [people[i:i+5] for i in range(0, len(people), 5)]
+
+        for group in groups:
+            irc_message = u'[[pushmaster {0}]] {1}{2}'.format(
+                self.current_user,
+                ', '.join(group) + ': ',
+                message,
+            )
+            subprocess.call([
+                '/nail/sys/bin/nodebot',
+                '-i',
+                irc_nick,
+                Settings['irc']['channel'],
+                irc_message
+            ])

--- a/pushmanager/tests/test_servlet_msg.py
+++ b/pushmanager/tests/test_servlet_msg.py
@@ -67,9 +67,9 @@ class MsgServletTest(T.TestCase, ServletTestMixin):
         """
 
         people = [
-            'asottile', 'milki', 'smoy', 'spatel', 'tdoran',
-            'tkadich1', 'tzhu', 'vpadmana', 'wtimoney', 'wting',
-            'osarood', 'pberens', 'perry', 'plucas',
+            'aaa', 'bbb', 'ccc', 'ddd', 'eee',
+            'fff', 'ggg', 'hhh', 'iii', 'jjj',
+            'kkk', 'lll', 'mmm', 'nnn',
         ]
 
         name_list = ''.join(['&people[]=' + person for person in people])
@@ -87,14 +87,18 @@ class MsgServletTest(T.TestCase, ServletTestMixin):
             message='multiple people should be divided into groups'
         )
 
-        for group in groups:
+        for i, group in enumerate(groups):
             self.call_mock.assert_any_call(
                 [
                     '/nail/sys/bin/nodebot',
                     '-i',
                     mock.ANY,
                     mock.ANY,
-                    '[[pushmaster testuser]] ' + (', ').join(group) + ': foo',
+                    '{0} {1}{2}'.format(
+                        '[[pushmaster testuser]]' if not i else '',
+                        (', ').join(group),
+                        ': foo' if i == len(groups) - 1 else '',
+                    )
                 ],
             )
 

--- a/pushmanager/tests/test_servlet_msg.py
+++ b/pushmanager/tests/test_servlet_msg.py
@@ -80,27 +80,41 @@ class MsgServletTest(T.TestCase, ServletTestMixin):
         )
         T.assert_is(resp.error, None)
 
-        groups = [people[i:i+5] for i in range(0, len(people), 5)]
         T.assert_equal(
             self.call_mock.call_count,
-            len(groups),
+            3,
             message='multiple people should be divided into groups'
         )
 
-        for i, group in enumerate(groups):
-            self.call_mock.assert_any_call(
-                [
-                    '/nail/sys/bin/nodebot',
-                    '-i',
-                    mock.ANY,
-                    mock.ANY,
-                    '{0} {1}{2}'.format(
-                        '[[pushmaster testuser]]' if not i else '',
-                        (', ').join(group),
-                        ': foo' if i == len(groups) - 1 else '',
-                    )
-                ],
-            )
+        self.call_mock.assert_any_call(
+            [
+                '/nail/sys/bin/nodebot',
+                '-i',
+                mock.ANY,
+                mock.ANY,
+                '[[pushmaster testuser]] aaa, bbb, ccc, ddd, eee',
+            ],
+        )
+
+        self.call_mock.assert_any_call(
+            [
+                '/nail/sys/bin/nodebot',
+                '-i',
+                mock.ANY,
+                mock.ANY,
+                ' fff, ggg, hhh, iii, jjj',
+            ],
+        )
+
+        self.call_mock.assert_any_call(
+            [
+                '/nail/sys/bin/nodebot',
+                '-i',
+                mock.ANY,
+                mock.ANY,
+                ' kkk, lll, mmm, nnn: foo',
+            ],
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixed #35 
divide people into groups and send them one by one.
