### PR TITLE
Release 0.3.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+0.3.7   2014-09-05
+
+ BUG FIXES
+
+ * Strip whitespace from sensitive request fields (rschlaikjer, #108)
+ * Expand the linkify regex to accept dashes and port numbers (fede1024, #110)
+
+ IMPROVEMENTS
+
+ * Split pushmanager messages across multiple lines to avoid max char limit
+   (Mango-J, #35, #106)
+ * Replaced the trac specific ticket link with a general link. (fede1024, #105)
+ * Improve pickme conflict detection (rschlaikjer, #104)
+
 0.3.6   2014-08-22
 
  BUG FIXES

--- a/UPDATING
+++ b/UPDATING
@@ -1,3 +1,10 @@
+2014.09.05
+  AFFECTS: Users with existing installs before 0.3.7
+  AUTHOR: milki
+
+  Config option trac.servername has been removed in favour of
+  ticket_tracker_url_format
+
 2014.08.22
   AFFECTS: Users with existing installs before 0.3.6
   AUTHOR: milki

--- a/pushmanager/__about__.py
+++ b/pushmanager/__about__.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 3, 6)
+__version_info__ = (0, 3, 7)
 __version__ = '%d.%d.%d' % __version_info__


### PR DESCRIPTION
 BUG FIXES
- Strip whitespace from sensitive request fields (rschlaikjer, #108)
- Expand the linkify regex to accept dashes and port numbers (fede1024, #110)
  
  IMPROVEMENTS
- Split pushmanager messages across multiple lines to avoid max char limit
  (Mango-J, #35, #106)
- Replaced the trac specific ticket link with a general link. (fede1024, #105)
- Improve pickme conflict detection (rschlaikjer, #104)
