### PR TITLE
Release 0.3.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+0.3.8   2014-09-10
+
+ IMPROVEMENTS
+
+ * Split new push announcement into multiple lines (Mango-J, #113)
+ * Comment dialogue box for a push request is larger (kkellyy, #114)
+
 0.3.7   2014-09-05
 
  BUG FIXES

--- a/pushmanager/__about__.py
+++ b/pushmanager/__about__.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 3, 7)
+__version_info__ = (0, 3, 8)
 __version__ = '%d.%d.%d' % __version_info__


### PR DESCRIPTION
 IMPROVEMENTS
- Split new push announcement into multiple lines (Mango-J, #113)
- Comment dialogue box for a push request is larger (kkellyy, #114)
