### PR TITLE
Correctly set port and scheme when behind proxy.

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -1194,7 +1194,7 @@ class GitQueue(object):
             <p>
                 <strong>%(user)s - %(title)s</strong><br />
                 <em>%(repo)s/%(branch)s</em><br />
-                <a href="%(pushmanager_url)s/request?id=%(id)s">%(pushmanager_url)srequest?id=%(id)s</a>
+                <a href="%(pushmanager_url)s/request?id=%(id)s">%(pushmanager_url)s/request?id=%(id)s</a>
             </p>
             <p>
                 Review # (if specified): <a href="https://%(reviewboard_servername)s%(pushmanager_port)s/r/%(reviewid)s">%(reviewid)s</a>

--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -1134,12 +1134,7 @@ class GitQueue(object):
                 ),
                 'pickme_name': updated_request['branch'],
                 'pickme_id': updated_request['id'],
-                'pushmanager_url' : pushmanager_url,
-                'pushmanager_port': (
-                    (':%d' % Settings['main_app']['port'])
-                    if Settings['main_app']['port'] != 443
-                    else ''
-                )
+                'pushmanager_url' : pushmanager_url
             }
         XMPPQueue.enqueue_user_xmpp([user_to_notify], msg)
 

--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -1133,6 +1133,7 @@ class GitQueue(object):
                     else "another pickme"
                 ),
                 'pickme_name': updated_request['branch'],
+                'pickme_id': updated_request['id'],
                 'pushmanager_url' : pushmanager_url,
                 'pushmanager_port': (
                     (':%d' % Settings['main_app']['port'])

--- a/pushmanager/core/requesthandler.py
+++ b/pushmanager/core/requesthandler.py
@@ -55,10 +55,10 @@ class RequestHandler(tornado.web.RequestHandler):
             )
 
     def get_base_url(self):
-        protocol = self.request.headers.get('X-Forwarded-Proto', 'https') 
+        default_ports = { 'https' : ':443', 'http' : ':80' }
+        protocol = self.request.headers.get('X-Forwarded-Proto', self.request.protocol).lower() 
         pushmanager_port = ':%s' % self.request.headers.get('X-Forwarded-Port', Settings['main_app']['port'])
-        if ((pushmanager_port == ':443' and protocol == 'https') 
-                or (pushmanager_port == ':80' and protocol == 'http')):
+        if default_ports[protocol] == pushmanager_port:
             pushmanager_port = ''
 
         pushmanager_base_url =  '%(protocol)s://%(pushmanager_servername)s%(pushmanager_port)s' % {

--- a/pushmanager/core/requesthandler.py
+++ b/pushmanager/core/requesthandler.py
@@ -2,10 +2,12 @@ import contextlib
 import json
 import urllib
 import urlparse
+import logging
 
 import tornado.httpclient
 import tornado.stack_context
 import tornado.web
+
 from pushmanager.core.settings import JSSettings
 from pushmanager.core.settings import Settings
 
@@ -52,6 +54,19 @@ class RequestHandler(tornado.web.RequestHandler):
                 method="POST",
                 body=urllib.urlencode(arguments)
             )
+
+    def get_base_url(self):
+        pushmanager_port = ':%s' % self.request.headers.get('X-Forwarded-Port', Settings['main_app']['port'])
+        if pushmanager_port == ':443':
+            pushmanager_port = ''
+
+        pushmanager_base_url =  '%(protocol)s://%(pushmanager_servername)s%(pushmanager_port)s' % {
+            'protocol' : self.request.headers.get('X-Forwarded-Proto', 'https'), 
+            'pushmanager_servername' : Settings['main_app']['servername'], 
+            'pushmanager_port' : pushmanager_port
+        }
+
+        return pushmanager_base_url
 
     def get_api_results(self, response):
         if response.error:

--- a/pushmanager/core/requesthandler.py
+++ b/pushmanager/core/requesthandler.py
@@ -55,16 +55,17 @@ class RequestHandler(tornado.web.RequestHandler):
             )
 
     def get_base_url(self):
+        protocol = self.request.headers.get('X-Forwarded-Proto', 'https') 
         pushmanager_port = ':%s' % self.request.headers.get('X-Forwarded-Port', Settings['main_app']['port'])
-        if pushmanager_port == ':443':
+        if ((pushmanager_port == ':443' and protocol == 'https') 
+                or (pushmanager_port == ':80' and protocol == 'http')):
             pushmanager_port = ''
 
         pushmanager_base_url =  '%(protocol)s://%(pushmanager_servername)s%(pushmanager_port)s' % {
-            'protocol' : self.request.headers.get('X-Forwarded-Proto', 'https'), 
+            'protocol' : protocol,
             'pushmanager_servername' : Settings['main_app']['servername'], 
             'pushmanager_port' : pushmanager_port
         }
-
         return pushmanager_base_url
 
     def get_api_results(self, response):

--- a/pushmanager/core/requesthandler.py
+++ b/pushmanager/core/requesthandler.py
@@ -2,7 +2,6 @@ import contextlib
 import json
 import urllib
 import urlparse
-import logging
 
 import tornado.httpclient
 import tornado.stack_context

--- a/pushmanager/core/requesthandler.py
+++ b/pushmanager/core/requesthandler.py
@@ -24,6 +24,21 @@ def async_api_call_error():
         else:
             raise
 
+def get_base_url(request):
+
+    default_ports = { 'https' : ':443', 'http' : ':80' }
+    protocol = request.headers.get('X-Forwarded-Proto', request.protocol).lower() 
+    pushmanager_port = ':%s' % request.headers.get('X-Forwarded-Port', Settings['main_app']['port'])
+    if default_ports[protocol] == pushmanager_port:
+        pushmanager_port = ''
+
+    pushmanager_base_url =  '%(protocol)s://%(pushmanager_servername)s%(pushmanager_port)s' % {
+            'protocol' : protocol,
+            'pushmanager_servername' : Settings['main_app']['servername'], 
+            'pushmanager_port' : pushmanager_port
+            }
+    return pushmanager_base_url
+
 class RequestHandler(tornado.web.RequestHandler):
 
     def get_current_user(self):
@@ -55,18 +70,7 @@ class RequestHandler(tornado.web.RequestHandler):
             )
 
     def get_base_url(self):
-        default_ports = { 'https' : ':443', 'http' : ':80' }
-        protocol = self.request.headers.get('X-Forwarded-Proto', self.request.protocol).lower() 
-        pushmanager_port = ':%s' % self.request.headers.get('X-Forwarded-Port', Settings['main_app']['port'])
-        if default_ports[protocol] == pushmanager_port:
-            pushmanager_port = ''
-
-        pushmanager_base_url =  '%(protocol)s://%(pushmanager_servername)s%(pushmanager_port)s' % {
-            'protocol' : protocol,
-            'pushmanager_servername' : Settings['main_app']['servername'], 
-            'pushmanager_port' : pushmanager_port
-        }
-        return pushmanager_base_url
+        return get_base_url(self.request)
 
     def get_api_results(self, response):
         if response.error:

--- a/pushmanager/handlers.py
+++ b/pushmanager/handlers.py
@@ -66,13 +66,7 @@ class LogoutHandler(RequestHandler):
     post = get
 
 
-class RedirHandler(tornado.web.RequestHandler):
+class RedirHandler(RequestHandler):
     def get(self, path):
-        pushmanager_servername = Settings['main_app']['servername']
-        pushmanager_servername = pushmanager_servername.rstrip('/')
-        pushmanager_port = ':%d' % Settings['main_app']['port'] if Settings['main_app']['port'] != 443 else ''
-
-        pushmanager_url = "https://%s/" % pushmanager_servername + pushmanager_port
-
-        self.redirect(urlparse.urljoin(pushmanager_url, path), permanent=True)
+        self.redirect(urlparse.urljoin(get_base_url(), path), permanent=True)
     post = get

--- a/pushmanager/handlers.py
+++ b/pushmanager/handlers.py
@@ -3,11 +3,8 @@ from __future__ import with_statement
 
 import urlparse
 
-import tornado.httpserver
-import tornado.web
 from pushmanager.core.auth import authenticate
 from pushmanager.core.requesthandler import RequestHandler
-from pushmanager.core.settings import Settings
 
 
 class NullRequestHandler(RequestHandler):
@@ -68,5 +65,5 @@ class LogoutHandler(RequestHandler):
 
 class RedirHandler(RequestHandler):
     def get(self, path):
-        self.redirect(urlparse.urljoin(get_base_url(), path), permanent=True)
+        self.redirect(urlparse.urljoin(self.get_base_url(), path), permanent=True)
     post = get

--- a/pushmanager/servlets/addrequest.py
+++ b/pushmanager/servlets/addrequest.py
@@ -3,7 +3,6 @@ import pushmanager.core.util
 from pushmanager.core.db import InsertIgnore
 from pushmanager.core.mail import MailQueue
 from pushmanager.core.requesthandler import RequestHandler
-from pushmanager.core.settings import Settings
 from pushmanager.core.xmppclient import XMPPQueue
 
 

--- a/pushmanager/servlets/addrequest.py
+++ b/pushmanager/servlets/addrequest.py
@@ -61,9 +61,8 @@ class AddRequestServlet(RequestHandler):
                 })
             subject = "[push] %s - %s" % (user_string, req['title'])
             MailQueue.enqueue_user_email(users, msg, subject)
-            msg = '%(pushmaster)s has accepted request "%(title)s" for %(user)s into a push:\nhttps://%(pushmanager_servername)s%(pushmanager_port)s/push?id=%(pushid)s' % {
-                'pushmanager_servername': Settings['main_app']['servername'],
-                'pushmanager_port': ':%d' % Settings['main_app']['port'] if Settings['main_app']['port'] != 443 else '',
+            msg = '%(pushmaster)s has accepted request "%(title)s" for %(user)s into a push:\n%(pushmanager_base_url)s/push?id=%(pushid)s' % {
+                'pushmanager_base_url' : self.get_base_url(),
                 'pushmaster': self.current_user,
                 'title': req['title'],
                 'pushid': self.pushid,

--- a/pushmanager/servlets/deploypush.py
+++ b/pushmanager/servlets/deploypush.py
@@ -62,8 +62,8 @@ class DeployPushServlet(RequestHandler):
                 </p>
                 <p>
                     Once you've checked that it works, mark it as verified here:
-                    <a href="https://%(pushmanager_servername)s%(pushmanager_port)s/push?id=%(pushid)s">
-                        https://%(pushmanager_servername)s%(pushmanager_port)s/push?id=%(pushid)s
+                    <a href="%(pushmanager_base_url)s/push?id=%(pushid)s">
+                        %(pushmanager_base_url)s/push?id=%(pushid)s
                     </a>
                 </p>
                 <p>
@@ -72,8 +72,7 @@ class DeployPushServlet(RequestHandler):
                 </p>"""
                 ) % pushmanager.core.util.EscapedDict({
                     'pushmaster': self.current_user,
-                    'pushmanager_servername': Settings['main_app']['servername'],
-                    'pushmanager_port' : ':%d' % Settings['main_app']['port'] if Settings['main_app']['port'] != 443 else '',
+                    'pushmanager_base_url': self.get_base_url(),
                     'user': user_string,
                     'title': req['title'],
                     'repo': req['repo'],
@@ -84,10 +83,9 @@ class DeployPushServlet(RequestHandler):
             subject = "[push] %s - %s" % (user_string, req['title'])
             MailQueue.enqueue_user_email(users, msg, subject)
 
-            msg = '%(pushmaster)s has deployed request "%(title)s" for %(user)s to %(pushstage)s.\nPlease verify it at https://%(pushmanager_servername)s%(pushmanager_port)s/push?id=%(pushid)s' % {
+            msg = '%(pushmaster)s has deployed request "%(title)s" for %(user)s to %(pushstage)s.\nPlease verify it at %(pushmanager_base_url)s/push?id=%(pushid)s' % {
                     'pushmaster': self.current_user,
-                    'pushmanager_servername': Settings['main_app']['servername'],
-                    'pushmanager_port': ':%d' % Settings['main_app']['port'] if Settings['main_app']['port'] != 443 else '',
+                    'pushmanager_base_url': self.get_base_url(),
                     'title': req['title'],
                     'pushid': self.pushid,
                     'user': user_string,

--- a/pushmanager/servlets/deploypush.py
+++ b/pushmanager/servlets/deploypush.py
@@ -4,7 +4,6 @@ import pushmanager.core.db as db
 import pushmanager.core.util
 from pushmanager.core.mail import MailQueue
 from pushmanager.core.requesthandler import RequestHandler
-from pushmanager.core.settings import Settings
 from pushmanager.core.xmppclient import XMPPQueue
 
 

--- a/pushmanager/servlets/newpush.py
+++ b/pushmanager/servlets/newpush.py
@@ -10,13 +10,10 @@ from pushmanager.core.xmppclient import XMPPQueue
 from pushmanager.core.util import send_people_msg_in_groups
 
 
-def send_notifications(people, pushtype, pushurl):
+def send_notifications(people, pushtype, pushurl, request):
     pushmanager_servername = Settings['main_app']['servername']
-    pushmanager_servername = pushmanager_servername.rstrip('/')
-    pushmanager_port = ':%d' % Settings['main_app']['port'] if Settings['main_app']['port'] != 443 else ''
+    pushmanager_url = request.get_base_url() + pushurl
 
-    pushurl = pushurl.lstrip('/')
-    pushmanager_url = "https://%s/%s" % (pushmanager_servername + pushmanager_port, pushurl)
 
     if people:
         msg = '%s: %s push starting! %s' % (', '.join(people), pushtype, pushmanager_url)
@@ -88,6 +85,6 @@ class NewPushServlet(RequestHandler):
         else:
             people = set(user for x in select_results for user in users_involved(x))
 
-        send_notifications(people, self.pushtype, pushurl)
+        send_notifications(people, self.pushtype, pushurl, self)
 
         return self.redirect(pushurl)

--- a/pushmanager/servlets/newpush.py
+++ b/pushmanager/servlets/newpush.py
@@ -10,10 +10,8 @@ from pushmanager.core.xmppclient import XMPPQueue
 from pushmanager.core.util import send_people_msg_in_groups
 
 
-def send_notifications(people, pushtype, pushurl, request):
+def send_notifications(people, pushtype, pushmanager_url):
     pushmanager_servername = Settings['main_app']['servername']
-    pushmanager_url = request.get_base_url() + pushurl
-
 
     if people:
         msg = '%s: %s push starting! %s' % (', '.join(people), pushtype, pushmanager_url)
@@ -72,6 +70,7 @@ class NewPushServlet(RequestHandler):
 
         insert_results, select_results = db_results
         pushurl = '/push?id=%s' % insert_results.lastrowid
+        pushmanager_url = self.get_base_url() + pushurl
 
         def users_involved(request):
             if request['watchers']:
@@ -85,6 +84,6 @@ class NewPushServlet(RequestHandler):
         else:
             people = set(user for x in select_results for user in users_involved(x))
 
-        send_notifications(people, self.pushtype, pushurl, self)
+        send_notifications(people, self.pushtype, pushmanager_url)
 
         return self.redirect(pushurl)

--- a/pushmanager/servlets/newrequest.py
+++ b/pushmanager/servlets/newrequest.py
@@ -141,12 +141,12 @@ class NewRequestServlet(RequestHandler):
             return self.send_error(500)
 
         if self.requestid:
-            GitQueue.enqueue_request(GitTaskAction.VERIFY_BRANCH, self.requestid)
+            GitQueue.enqueue_request(GitTaskAction.VERIFY_BRANCH, self.requestid, pushmanager_url = self.get_base_url())
 
             # Check if the request is already pickme'd for a push, and if
             # so also enqueue it to be checked for conflicts.
             request_push_id = GitQueue._get_push_for_request(self.requestid)
             if request_push_id:
-                GitQueue.enqueue_request(GitTaskAction.TEST_PICKME_CONFLICT, self.requestid)
+                GitQueue.enqueue_request(GitTaskAction.TEST_PICKME_CONFLICT, self.requestid, pushmanager_url = self.get_base_url())
 
         return self.redirect("/requests?user=%s" % self.request_user)

--- a/pushmanager/servlets/pickmerequest.py
+++ b/pushmanager/servlets/pickmerequest.py
@@ -61,7 +61,7 @@ class PickMeRequestServlet(RequestHandler):
     def on_db_complete(self, success, db_results):
         self.check_db_results(success, db_results)
         for request_id in self.request_ids:
-            GitQueue.enqueue_request(GitTaskAction.TEST_PICKME_CONFLICT, request_id)
+            GitQueue.enqueue_request(GitTaskAction.TEST_PICKME_CONFLICT, request_id, pushmanager_url = self.get_base_url())
 
 class UnpickMeRequestServlet(RequestHandler):
 

--- a/pushmanager/servlets/verifyrequest.py
+++ b/pushmanager/servlets/verifyrequest.py
@@ -46,9 +46,8 @@ class VerifyRequestServlet(RequestHandler):
 
         push = db_results[0].first()
         unfinished_requests = db_results[2].first()
-        pushmanager_servername = Settings['main_app']['servername']
-        pushmanager_port = ':%d' % Settings['main_app']['port'] if Settings['main_app']['port'] != 443 else ''
+        pushmanager_base_url = self.get_base_url()
         if not unfinished_requests:
-            msg = "All currently staged requests in https://%s/push?id=%s have been marked as verified." % \
-                (pushmanager_servername + pushmanager_port, self.pushid)
+            msg = "All currently staged requests in %s/push?id=%s have been marked as verified." % \
+                (pushmanager_base_url, self.pushid)
             XMPPQueue.enqueue_user_xmpp([push['user']], msg)

--- a/pushmanager/servlets/verifyrequest.py
+++ b/pushmanager/servlets/verifyrequest.py
@@ -3,7 +3,6 @@ import sqlalchemy as SA
 import pushmanager.core.db as db
 import pushmanager.core.util
 from pushmanager.core.requesthandler import RequestHandler
-from pushmanager.core.settings import Settings
 from pushmanager.core.xmppclient import XMPPQueue
 
 

--- a/pushmanager/tests/test_core_git.py
+++ b/pushmanager/tests/test_core_git.py
@@ -83,7 +83,7 @@ class CoreGitTest(T.TestCase):
                 return_value=duplicate_req
             ),
         ):
-            pushmanager.core.git.GitQueue.verify_branch(req['id'])
+            pushmanager.core.git.GitQueue.verify_branch(req['id'], 'http://fake-url.com')
             yield
 
     def test_get_repository_uri_basic(self):
@@ -172,7 +172,7 @@ class CoreGitTest(T.TestCase):
             # (from mock library).
             T.assert_in(
                 "another request with the same revision sha",
-                pushmanager.core.git.GitQueue.verify_branch_failure.call_args_list[0][0][-1]
+                pushmanager.core.git.GitQueue.verify_branch_failure.call_args_list[0][0][1]
             )
 
     def test_update_duplicate_request_discarded(self):
@@ -190,7 +190,7 @@ class CoreGitTest(T.TestCase):
         with mock.patch('pushmanager.core.git.GitCommand') as GC:
             GC.return_value = GC
             GC.run.return_value = (0, "hashashash", "")
-            pushmanager.core.git.GitQueue.verify_branch(1)
+            pushmanager.core.git.GitQueue.verify_branch(1, 'http://fake-url.com')
             calls = [
                  mock.call('ls-remote', '-h', u'git://git.example.com/devs/bmetin', u'bmetin_fix_stuff'),
                  mock.call.run()
@@ -202,7 +202,7 @@ class CoreGitTest(T.TestCase):
             mock.patch("%s.pushmanager.core.git.MailQueue.enqueue_user_email" % __name__),
             mock.patch("%s.pushmanager.core.git.webhook_req" % __name__)
         ):
-            pushmanager.core.git.GitQueue.verify_branch_successful(self.fake_request)
+            pushmanager.core.git.GitQueue.verify_branch_successful(self.fake_request, 'http://fake-url.com')
             T.assert_equal(pushmanager.core.git.MailQueue.enqueue_user_email.call_count, 1)
             T.assert_equal(pushmanager.core.git.webhook_req.call_count, 3)
 
@@ -212,7 +212,7 @@ class CoreGitTest(T.TestCase):
             mock.patch("%s.pushmanager.core.git.webhook_req" % __name__),
             mock.patch("%s.pushmanager.core.git.logging.error" % __name__),
         ):
-            pushmanager.core.git.GitQueue.verify_branch_failure(self.fake_request, "fake failure")
+            pushmanager.core.git.GitQueue.verify_branch_failure(self.fake_request, "fake failure", 'http://fake-url.com')
             T.assert_equal(pushmanager.core.git.MailQueue.enqueue_user_email.call_count, 1)
 
     def test_verify_branch_excluded_from_git_verification(self):

--- a/pushmanager/tests/test_core_git.py
+++ b/pushmanager/tests/test_core_git.py
@@ -83,7 +83,7 @@ class CoreGitTest(T.TestCase):
                 return_value=duplicate_req
             ),
         ):
-            pushmanager.core.git.GitQueue.verify_branch(req['id'], 'http://fake-url.com')
+            pushmanager.core.git.GitQueue.verify_branch(req['id'], 'http://example.com')
             yield
 
     def test_get_repository_uri_basic(self):
@@ -190,7 +190,7 @@ class CoreGitTest(T.TestCase):
         with mock.patch('pushmanager.core.git.GitCommand') as GC:
             GC.return_value = GC
             GC.run.return_value = (0, "hashashash", "")
-            pushmanager.core.git.GitQueue.verify_branch(1, 'http://fake-url.com')
+            pushmanager.core.git.GitQueue.verify_branch(1, 'http://example.com')
             calls = [
                  mock.call('ls-remote', '-h', u'git://git.example.com/devs/bmetin', u'bmetin_fix_stuff'),
                  mock.call.run()
@@ -202,7 +202,7 @@ class CoreGitTest(T.TestCase):
             mock.patch("%s.pushmanager.core.git.MailQueue.enqueue_user_email" % __name__),
             mock.patch("%s.pushmanager.core.git.webhook_req" % __name__)
         ):
-            pushmanager.core.git.GitQueue.verify_branch_successful(self.fake_request, 'http://fake-url.com')
+            pushmanager.core.git.GitQueue.verify_branch_successful(self.fake_request, 'http://example.com')
             T.assert_equal(pushmanager.core.git.MailQueue.enqueue_user_email.call_count, 1)
             T.assert_equal(pushmanager.core.git.webhook_req.call_count, 3)
 
@@ -212,7 +212,7 @@ class CoreGitTest(T.TestCase):
             mock.patch("%s.pushmanager.core.git.webhook_req" % __name__),
             mock.patch("%s.pushmanager.core.git.logging.error" % __name__),
         ):
-            pushmanager.core.git.GitQueue.verify_branch_failure(self.fake_request, "fake failure", 'http://fake-url.com')
+            pushmanager.core.git.GitQueue.verify_branch_failure(self.fake_request, "fake failure", 'http://example.com')
             T.assert_equal(pushmanager.core.git.MailQueue.enqueue_user_email.call_count, 1)
 
     def test_verify_branch_excluded_from_git_verification(self):

--- a/pushmanager/tests/test_core_requesthandler.py
+++ b/pushmanager/tests/test_core_requesthandler.py
@@ -2,10 +2,13 @@
 
 import mock
 import testify as T
+
+import  tornado.httpserver
+
 from pushmanager.core.requesthandler import RequestHandler
+from pushmanager.core.requesthandler import get_base_url
 from pushmanager.core.settings import Settings
 from pushmanager.testing.mocksettings import MockedSettings
-
 
 class RequestHandlerTest(T.TestCase):
 
@@ -15,4 +18,75 @@ class RequestHandlerTest(T.TestCase):
             T.assert_equal(
                 RequestHandler.get_api_page("pushes"),
                 "http://push.test.com:8043/api/pushes"
+            )
+
+    def test_get_base_url_empty_headers(self):
+        MockedSettings['main_app'] = {'port': 1111, 'servername': 'example.com'}
+        request = tornado.httpserver.HTTPRequest('GET', '')
+        request.protocol = 'https'
+        
+        with mock.patch.dict(Settings, MockedSettings):
+            T.assert_equal(
+                get_base_url(request),
+                'https://example.com:1111'
+            )
+
+            Settings['main_app']['port'] = 443
+            T.assert_equal(
+                get_base_url(request),
+                'https://example.com'
+            )
+
+    def test_get_base_url_proto_header(self):
+        MockedSettings['main_app'] = {'port': 1111, 'servername': 'example.com'}
+        request = tornado.httpserver.HTTPRequest('GET', '')
+        request.protocol = 'https'
+        request.headers['X-Forwarded-Proto'] = 'http'
+        
+        with mock.patch.dict(Settings, MockedSettings):
+            T.assert_equal(
+                get_base_url(request),
+                'http://example.com:1111'
+            )
+            
+            Settings['main_app']['port'] = 80
+            T.assert_equal(
+                get_base_url(request),
+                'http://example.com'
+            )
+
+    def test_get_base_url_port_header(self):
+        MockedSettings['main_app'] = {'port': 1111, 'servername': 'example.com'}
+        request = tornado.httpserver.HTTPRequest('GET', '')
+        request.protocol = 'https'
+        request.headers['X-Forwarded-Port'] = '4321'
+        
+        with mock.patch.dict(Settings, MockedSettings):
+            T.assert_equal(
+                get_base_url(request),
+                'https://example.com:4321'
+            )
+
+            request.headers['X-Forwarded-Port'] = 443
+            T.assert_equal(
+                get_base_url(request),
+                'https://example.com'
+            )
+
+
+    def test_RequestHandler_get_base_url(self):
+        MockedSettings['main_app'] = {'port': 1111, 'servername': 'example.com'}
+        request = tornado.httpserver.HTTPRequest('GET', '')
+        request.protocol = 'https'
+        class FakeRequest(object):
+            def __init__(self):
+                 self.request = request
+        
+        with mock.patch.dict(Settings, MockedSettings):
+            fake_requesthandler = FakeRequest()
+            T.assert_equal(
+                #Accessing raw, unbound function, so that type of self is not checked
+                #http://stackoverflow.com/a/12935356
+                RequestHandler.get_base_url.__func__(fake_requesthandler),
+                'https://example.com:1111'
             )

--- a/pushmanager/tests/test_servlet_newpush.py
+++ b/pushmanager/tests/test_servlet_newpush.py
@@ -77,7 +77,7 @@ class NewPushServletTest(T.TestCase, ServletTestMixin):
         mocked_self.check_db_results = mock.Mock(return_value=None)
         mocked_self.redirect = mock.Mock(return_value=None)
         mocked_self.pushtype = 'normal'
-        mocked_self.get_base_url = mock.Mock(return_value="http://fakeurl.com")
+        mocked_self.get_base_url = mock.Mock(return_value="http://example.com")
 
         mocked_self.on_db_complete = types.MethodType(NewPushServlet.on_db_complete.im_func, mocked_self)
 


### PR DESCRIPTION
<h4> Pushmanager now forms its URLs with information from any proxy it might be behind. </h4>


For pushmanager to do this, the proxy must forward its port and scheme via HTTP headers. Pushmanager uses the `X-Forwarded-Port` and `X-Forwarded-Proto` headers for this. 
- If the `X-Forwarded-Port` is set, then it will override the default of `Settings['main-app']['port']`. 
- If the `X-Forwarded-Proto` is set, then it will override the default of `https`.

For nginx, add these to `http`, `server`, or `location` blocks:

```
proxy_set_header X-Forwarded-Port $server_port;
proxy_set_header X-Forwarded-Proto $scheme;
```

For apache2, can add these (or write logic to determine port & protocol):

```
RequestHeader set X-Forwarded-Port 443
Requestheader set X-Forwarded-Proto "http"
```
