### PR TITLE
The 'git-ok' request tag now has gitweb link to the requested branch.

### DIFF
--- a/pushmanager/tests/test_ui_modules.py
+++ b/pushmanager/tests/test_ui_modules.py
@@ -1,0 +1,32 @@
+import mock
+import testify as T
+from pushmanager.ui_modules import Request
+from pushmanager.core.settings import Settings
+from pushmanager.testing.mocksettings import MockedSettings
+
+class StubHandler(object):
+    def __init__(self):
+        self.request = 'request'
+        self.ui = 'ui'
+        self.current_user = 'curr_user'
+        self.locale = 'the_moon'
+
+class UIModuleTest(T.TestCase):
+
+    def test_generate_tag_list_no_special(self):
+        request = Request(StubHandler())
+        request_info = {'tags':'git-not-ok', 'branch':'test'}
+        MockedSettings['git']['gitweb_servername'] = 'example.com'
+        with mock.patch.dict(Settings, MockedSettings):
+            gen_tags = request._generate_tag_list(request_info, 'repo')
+            T.assert_equals(gen_tags[0][1], None)
+
+
+
+    def test_generate_tag_list_gitok(self):
+        request = Request(StubHandler())
+        request_info = {'tags':'git-ok', 'branch':'test'}
+        MockedSettings['git']['gitweb_servername'] = 'example.com'
+        with mock.patch.dict(Settings, MockedSettings):
+            gen_tags = request._generate_tag_list(request_info, 'repo')
+            T.assert_equals(gen_tags[0][1], 'https://example.com/?p=repo.git;a=log;h=refs/heads/test')

--- a/pushmanager/ui_modules.py
+++ b/pushmanager/ui_modules.py
@@ -68,6 +68,13 @@ class Request(UIModule):
         if 'buildbot' in tags:
             tags['buildbot'] = "https://%s/rev/%s" % (Settings['buildbot']['servername'], request['revision'])
 
+        if 'git-ok' in tags:
+            tags['git-ok'] = 'https://%s/?p=%s.git;a=log;h=refs/heads/%s' % (
+                Settings['git']['gitweb_servername'],
+                repo,
+                request['branch']
+            )
+
         if 'pushplans' in tags:
             tags['pushplans'] = "https://%s/?p=%s.git;a=history;f=pushplans;hb=refs/heads/%s" % (
                 Settings['git']['gitweb_servername'],


### PR DESCRIPTION
If a request has a git-ok tag, it will now be a link to the dev's requested branch. 
Should save pushmaster time to go to the request to do the same thing.
