### PR TITLE
Remove post-stage necessary checklist item for 'hoods' tag

### DIFF
--- a/pushmanager/servlets/checklist.py
+++ b/pushmanager/servlets/checklist.py
@@ -17,7 +17,6 @@ checklist_reminders = {
     },
     'hoods': {
         'stage': 'Notify %(pushee)s to deploy Geoservices to stage.',
-        'post-stage': 'Ask Search to force index distribution on stage for %(pushee)s',
         'prod': 'Notify %(pushee)s to deploy Geoservices to prod.',
     },
     'pushplans-cleanup': {

--- a/pushmanager/servlets/newrequest.py
+++ b/pushmanager/servlets/newrequest.py
@@ -6,6 +6,7 @@ import sqlalchemy as SA
 import pushmanager.core.db as db
 import pushmanager.core.util
 from pushmanager.core.git import GitQueue
+from pushmanager.servlets.checklist import checklist_reminders
 from pushmanager.core.git import GitTaskAction
 from pushmanager.core.requesthandler import RequestHandler
 
@@ -115,20 +116,8 @@ class NewRequestServlet(RequestHandler):
         types_to_add = necessary_checklist_types - existing_checklist_types
         types_to_remove = existing_checklist_types - necessary_checklist_types
 
-        # Different types of checklist items need to happen at different points.
-        targets_by_type = {
-            'pushplans' : ('stage', 'prod'),
-            'search' : ('post-stage', 'prod', 'post-prod', 'post-verify'),
-            'hoods' : ('stage', 'post-stage', 'prod'),
-            # We need to append checklist items to clean up after
-            # push plans & search checklist items.
-            'pushplans-cleanup' : ('post-verify-stage',),
-            'search-cleanup': ('post-verify-prod',),
-            'hoods-cleanup' : ('post-verify-stage',),
-        }
-
         for type_ in types_to_add:
-            for target in targets_by_type[type_]:
+            for target in checklist_reminders[type_].keys():
                 queries.append(db.push_checklist.insert().values(
                     {'request': self.requestid, 'type': type_, 'target': target}
                 ))

--- a/pushmanager/servlets/newrequest.py
+++ b/pushmanager/servlets/newrequest.py
@@ -103,15 +103,12 @@ class NewRequestServlet(RequestHandler):
 
         necessary_checklist_types = set()
 
-        if 'pushplans' in self.tag_list:
-            necessary_checklist_types.add('pushplans')
-            necessary_checklist_types.add('pushplans-cleanup')
-        if 'search-backend' in self.tag_list:
-            necessary_checklist_types.add('search')
-            necessary_checklist_types.add('search-cleanup')
-        if 'hoods' in self.tag_list:
-            necessary_checklist_types.add('hoods')
-            necessary_checklist_types.add('hoods-cleanup')
+        canonical_tag_name = { 'search': 'search-backend' }
+        for cl_type in ['pushplans', 'search', 'hoods']:
+            tag = canonical_tag_name.get(cl_type, cl_type)
+            if tag in self.tag_list:
+                necessary_checklist_types.add(cl_type)
+                necessary_checklist_types.add('{0}-cleanup'.format(cl_type))
 
         types_to_add = necessary_checklist_types - existing_checklist_types
         types_to_remove = existing_checklist_types - necessary_checklist_types

--- a/pushmanager/tests/test_servlet_checklist.py
+++ b/pushmanager/tests/test_servlet_checklist.py
@@ -172,7 +172,6 @@ class ChecklistServletTest(T.TestCase, ServletTestMixin, FakeDataMixin):
             T.assert_not_in("No checklist items for this push", response.body)
             T.assert_in("Notify testuser1 to deploy Geoservices to stage", response.body)
             T.assert_in("Notify testuser1 to deploy Geoservices to prod", response.body)
-            T.assert_in("Ask Search to force index distribution on stage for testuser1", response.body)
 
 
 class ChecklistToggleServletTest(T.TestCase, ServletTestMixin, FakeDataMixin):

--- a/pushmanager/tests/test_servlet_checklist.py
+++ b/pushmanager/tests/test_servlet_checklist.py
@@ -158,7 +158,6 @@ class ChecklistServletTest(T.TestCase, ServletTestMixin, FakeDataMixin):
             checklist_queries = []
             checklist_items = (
                 {'request': req['id'], 'type': 'hoods', 'target': 'stage'},
-                {'request': req['id'], 'type': 'hoods', 'target': 'post-stage'},
                 {'request': req['id'], 'type': 'hoods', 'target': 'prod'},
                 {'request': req['id'], 'type': 'hoods-cleanup', 'target': 'post-verify-stage'},
             )

--- a/pushmanager/tests/test_servlet_newrequest.py
+++ b/pushmanager/tests/test_servlet_newrequest.py
@@ -242,19 +242,19 @@ class NewRequestChecklistMixin(ServletTestMixin, FakeDataMixin):
         return self.get_requests()[-1]['id']
 
     def get_checklists(self, requestid):
-        checklists = [None]
+        checklists = list()
         def on_select_return(success, db_results):
             assert success
-            checklists[0] = db_results.fetchall()
+            for cl in db_results.fetchall():
+                # id, *request*, *type*, complete, *target*
+                checklists.append((cl[1], cl[2], cl[4]))
 
         select_query = db.push_checklist.select().where(
                 db.push_checklist.c.request == requestid)
 
         db.execute_cb(select_query, on_select_return)
 
-        # id, *request*, *type*, complete, *target*
-        simple_checklists = [(cl[1], cl[2], cl[4]) for cl in checklists[0]]
-        return simple_checklists
+        return checklists
 
     def assert_checklist_for_tags(self, tags, requestid=None):
         num_checks = 0

--- a/pushmanager/tests/test_servlet_newrequest.py
+++ b/pushmanager/tests/test_servlet_newrequest.py
@@ -271,13 +271,13 @@ class NewRequestChecklistMixin(ServletTestMixin, FakeDataMixin):
                 continue
 
             plain_list = checklist_reminders[tag]
-            num_checks += len(plain_list)
             checks += [(tag, check) for check in plain_list]
 
             cleanup_tag = '%s-cleanup' % tag
             cleanup_list = checklist_reminders[cleanup_tag]
-            num_checks += len(cleanup_list)
             checks += [(cleanup_tag, check) for check in cleanup_list]
+
+        num_checks = len(checks)
 
         reqid = self.make_request_with_tags(tags, requestid)
         checklists = self.get_checklists(reqid)


### PR DESCRIPTION
No longer required for the hoods tag workflow. This pull-request also includes some refactoring for readability in regards for how tags and checklist items are parsed and generated. 

Tests started failing when I just removed the checklist item line and finding out why was non-trivial.
