### PR TITLE
Allow for generic dynamic tag for testing frameworks to fill in data

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -73,9 +73,11 @@ tests_tag:
     # JSON 'tag' value from POST response of this URL will replace tag
     tag_api_endpoint: "http://example.com/api/v1/tests_tag"
     tag_api_body: '{ "sha" : "%SHA%" }'
-    # If defined, tag will link to the JSON 'url' value from POST response of this URL
+    # If defined, tag will link to servername below and replace %ID%
+    # with the 'id' field in the JSON returned by url_api
     url_api_endpoint: "http://example.com/api/v1/test_results_url"
     url_api_body: '{ "sha" : "%SHA%" }'
+    #the run's ID from api will replace %ID% 
     servername: "example.com"
 
 # The string %TICKET% will be replaced by the ticket id

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -65,10 +65,10 @@ reviewboard:
 buildbot:
     servername: buildbot.mydomain.com
 
-# Set dynamic test tag using a REST api
+# Set dynamic test tag using a REST api (http or https)
 # Request's SHA will replace %SHA%
 tests_tag:
-    #User-added tag that will be replaced with api result
+    # User-added tag that will be replaced with api result
     tag: "test-framework"
     # JSON 'tag' value from POST response of this URL will replace tag
     tag_api_endpoint: "http://example.com/api/v1/tests_tag"
@@ -77,8 +77,8 @@ tests_tag:
     # with the 'id' field in the JSON returned by url_api
     url_api_endpoint: "http://example.com/api/v1/test_results_url"
     url_api_body: '{ "sha" : "%SHA%" }'
-    #the run's ID from api will replace %ID% 
-    servername: "example.com"
+    # The run's ID from api will replace %ID% 
+    servername: "example.com/run/%SHA%/%ID%"
 
 # The string %TICKET% will be replaced by the ticket id
 ticket_tracker_url_format: "http://server:port/path/%TICKET%"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -65,6 +65,18 @@ reviewboard:
 buildbot:
     servername: buildbot.mydomain.com
 
+# Set dynamic test tag using a REST api
+# Request's SHA will replace %SHA%
+tests_tag:
+    #User-added tag that will be replaced with api result
+    tag: "test-framework"
+    # JSON 'tag' value from POST response of this URL will replace tag
+    tag_api_endpoint: "http://example.com/api/v1/tests_tag"
+    tag_api_body: '{ "sha" : "%SHA%" }'
+    # If defined, tag will link to the JSON 'url' value from POST response of this URL
+    url_api_endpoint: "http://example.com/api/v1/test_results_url"
+    url_api_body: '{ "sha" : "%SHA%" }'
+
 # The string %TICKET% will be replaced by the ticket id
 ticket_tracker_url_format: "http://server:port/path/%TICKET%"
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -76,6 +76,7 @@ tests_tag:
     # If defined, tag will link to the JSON 'url' value from POST response of this URL
     url_api_endpoint: "http://example.com/api/v1/test_results_url"
     url_api_body: '{ "sha" : "%SHA%" }'
+    servername: "example.com"
 
 # The string %TICKET% will be replaced by the ticket id
 ticket_tracker_url_format: "http://server:port/path/%TICKET%"

--- a/pushmanager/core/settings.py
+++ b/pushmanager/core/settings.py
@@ -39,6 +39,8 @@ JSSettings = {
     },
     'check_sites_bookmarklet': None,
 }
+if 'tests_tag' in Settings:
+    JSSettings['tests_tag'] = {'tag': None}
 
 dict_copy_keys(to_dict=JSSettings, from_dict=Settings)
 

--- a/pushmanager/pushmanager_main.py
+++ b/pushmanager/pushmanager_main.py
@@ -47,6 +47,7 @@ from pushmanager.servlets.removerequest import RemoveRequestServlet
 from pushmanager.servlets.request import RequestServlet
 from pushmanager.servlets.requests import RequestsServlet
 from pushmanager.servlets.smartdest import SmartDestServlet
+from pushmanager.servlets.testtag import TestTagServlet
 from pushmanager.servlets.summaryforbranch import SummaryForBranchServlet
 from pushmanager.servlets.undelayrequest import UndelayRequestServlet
 from pushmanager.servlets.userlist import UserListServlet
@@ -92,7 +93,8 @@ def get_url_specs():
                     PushByRequestServlet,
                     UserListServlet,
                     SummaryForBranchServlet,
-                    MsgServlet):
+                    MsgServlet,
+                    TestTagServlet):
         url_specs.append(get_servlet_urlspec(servlet))
     return url_specs
 

--- a/pushmanager/servlets/testtag.py
+++ b/pushmanager/servlets/testtag.py
@@ -1,0 +1,56 @@
+import json
+import logging
+import urllib2
+
+import pushmanager.core.util
+
+from pushmanager.core.git import GitQueue
+from pushmanager.core.requesthandler import RequestHandler
+from pushmanager.core.settings import Settings
+from tornado.escape import url_escape
+from tornado.escape import xhtml_escape
+
+
+class TestTagServlet(RequestHandler):
+
+    def _arg(self, key):
+        return pushmanager.core.util.get_str_arg(self.request, key, '')
+
+    def get(self):
+        self.request_id = pushmanager.core.util.get_int_arg(self.request, 'id')
+        request = GitQueue._get_request(self.request_id)
+        self.write(self._gen_test_tag_resp(request))
+
+    @classmethod
+    def _gen_test_tag_resp(cls, request):
+        response = {}
+
+        if 'tests_tag' in Settings and Settings['tests_tag']['tag'] in request['tags']:
+            response['tag'] = Settings['tests_tag']['tag']
+            try:
+                api_url = Settings['tests_tag']['tag_api_endpoint'].replace('%SHA%', request['revision'])
+                api_body = Settings['tests_tag']['tag_api_body'].replace('%SHA%', request['revision'])
+                api_resp = urllib2.urlopen(api_url, api_body)
+                response['tag'] = xhtml_escape(json.loads(api_resp.read())['tag'])
+            except Exception as e:
+                response['tag'] += ": ERROR connecting to server"
+                logging.error(e)
+
+            response['url'] = ''
+            if 'url_api_endpoint' in Settings['tests_tag']:
+                try:
+                    result_api_url = Settings['tests_tag']['url_api_endpoint'].replace('%SHA%', request['revision'])
+                    result_api_body = Settings['tests_tag']['url_api_body'].replace('%SHA%', request['revision'])
+                    resp = urllib2.urlopen(result_api_url, result_api_body)
+                    result_id = url_escape(json.loads(resp.read())['id'])
+                    if result_id != '':
+                        response['url'] = Settings['tests_tag']['servername'].replace('%ID%', result_id).replace('%SHA%', request['revision'])
+                except Exception as e:
+                    logging.warning(e)
+                    logging.warning("Couldn't load results for results test URL from %s with body %s" %
+                            (
+                                Settings['tests_tag']['url_api_endpoint'].replace('%SHA%', request['revision']),
+                                Settings['tests_tag']['url_api_body'].replace('%SHA%', request['revision'])
+                            )
+                        )
+        return response

--- a/pushmanager/servlets/testtag.py
+++ b/pushmanager/servlets/testtag.py
@@ -2,13 +2,13 @@ import json
 import logging
 import urllib2
 
-import pushmanager.core.util
+from tornado.escape import url_escape
+from tornado.escape import xhtml_escape
 
+import pushmanager.core.util
 from pushmanager.core.git import GitQueue
 from pushmanager.core.requesthandler import RequestHandler
 from pushmanager.core.settings import Settings
-from tornado.escape import url_escape
-from tornado.escape import xhtml_escape
 
 
 class TestTagServlet(RequestHandler):

--- a/pushmanager/static/js/modules/request.js
+++ b/pushmanager/static/js/modules/request.js
@@ -176,7 +176,7 @@ $(function() {
                 that.addClass('test-data-loaded');
             },
             'error': function(XMLHttpRequest, textStatus, errorThrown){
-                alert('status:' + XMLHttpRequest.status + ', status text: ' + XMLHttpRequest.statusText);
+                console.log('status:' + XMLHttpRequest.status + ', status text: ' + XMLHttpRequest.statusText);
             }
         });
     };

--- a/pushmanager/static/js/modules/request.js
+++ b/pushmanager/static/js/modules/request.js
@@ -148,6 +148,36 @@ $(function() {
                 }
                 that.addClass('bb-data-loaded');
             }
+            });
+    };
+
+    PushManager.Request.load_test_api_tags= function(domobj) {
+        var that = $(domobj);
+        if(that.hasClass('test-data-loaded')) {
+            return;
+        }
+        var req = that.closest('.request-module');
+        var id = req.attr('request');
+        $.ajax({
+            'url': '/testtag',
+            'data': {'id': id},
+            'dataType': 'json',
+            'success': function(data) {
+                if(!data || data.error) {
+                    that.append(' (<span style="color: #f08;">INTERNAL ERROR</span>)');
+                } else {
+                    that.text('');
+                    if (data['url'].length === 0){
+                        that.text(data['tag']);
+                    } else {
+                        that.append('<a href='+data['url']+'>'+data['tag']+'</a>');
+                    }
+                }
+                that.addClass('test-data-loaded');
+            },
+            'error': function(XMLHttpRequest, textStatus, errorThrown){
+                alert('status:' + XMLHttpRequest.status + ', status text: ' + XMLHttpRequest.statusText);
+            }
         });
     };
 });

--- a/pushmanager/static/js/push.js
+++ b/pushmanager/static/js/push.js
@@ -1,4 +1,5 @@
 $(function() {
+    Settings = window.Settings;
     PushManager = window.PushManager || {};
 
     $('#push-checklist').dialog({
@@ -511,6 +512,12 @@ $(function() {
     setTimeout(function() {
         $('.tag-buildbot').each(function() { PushManager.Request.load_bb_failures(this); });
     }, 1000);
+
+    if ('tests_tag' in Settings) {
+        setTimeout(function() {
+            $('.tag-'+Settings['tests_tag']['tag']).each(function() { PushManager.Request.load_test_api_tags(this); });
+        }, 1000)
+    }
 
     $('#push-survey').dialog({
         autoOpen: false,

--- a/pushmanager/tests/test_servlet_testtag.py
+++ b/pushmanager/tests/test_servlet_testtag.py
@@ -1,0 +1,55 @@
+import mock
+import testify as T
+
+from pushmanager.testing.mocksettings import MockedSettings
+from pushmanager.servlets.testtag import TestTagServlet
+from pushmanager.core.settings import Settings
+
+
+class TestTagServletTest(T.TestCase):
+
+    @mock.patch('pushmanager.servlets.testtag.urllib2.urlopen')
+    def test_generate_test_tag_normal(self, mock_urlopen):
+        m = mock.Mock()
+        m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"id" : "123"}']
+        mock_urlopen.return_value = m
+
+        MockedSettings['tests_tag'] = {}
+        MockedSettings['tests_tag']['tag'] = 'test'
+        MockedSettings['tests_tag']['tag_api_endpoint'] = 'example.com'
+        MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
+        MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
+        MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
+        MockedSettings['tests_tag']['servername'] = 'www.example.com/%ID%'
+
+        request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
+        with mock.patch.dict(Settings, MockedSettings):
+            gen_tags = TestTagServlet._gen_test_tag_resp(request_info)
+            T.assert_equals({'tag': 'tag 0 fails', 'url': "www.example.com/123"}, gen_tags)
+
+    @mock.patch('pushmanager.servlets.testtag.urllib2.urlopen')
+    def test_generate_test_tag_no_url(self, mock_urlopen):
+        m = mock.Mock()
+        m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"url" : ""}']
+        mock_urlopen.return_value = m
+
+        MockedSettings['tests_tag'] = {}
+        MockedSettings['tests_tag']['tag'] = 'test'
+        MockedSettings['tests_tag']['tag_api_endpoint'] = 'example.com'
+        MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
+        MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
+        MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
+        MockedSettings['tests_tag']['servername'] = 'www.example.com/%ID$'
+
+        request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
+        with mock.patch.dict(Settings, MockedSettings):
+            gen_tags = TestTagServlet._gen_test_tag_resp(request_info)
+            T.assert_equals({'tag': 'tag 0 fails', 'url': ""}, gen_tags)
+
+    def test_generate_test_tag_none(self):
+        del MockedSettings['tests_tag']
+
+        request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
+        with mock.patch.dict(Settings, MockedSettings):
+            gen_tags = TestTagServlet._gen_test_tag_resp(request_info)
+            T.assert_equals({}, gen_tags)

--- a/pushmanager/tests/test_ui_modules.py
+++ b/pushmanager/tests/test_ui_modules.py
@@ -37,6 +37,7 @@ class UIModuleTest(T.TestCase):
         m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"url" : "www.example.com/results/sha"}']
         mock_urlopen.return_value = m
 
+        MockedSettings['tests_tag'] = {}
         MockedSettings['tests_tag']['tag'] = 'test'
         MockedSettings['tests_tag']['tag_api_endpoint'] = 'example.com'
         MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
@@ -55,6 +56,7 @@ class UIModuleTest(T.TestCase):
         m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"url" : ""}']
         mock_urlopen.return_value = m
 
+        MockedSettings['tests_tag'] = {}
         MockedSettings['tests_tag']['tag'] = 'test'
         MockedSettings['tests_tag']['tag_api_endpoint'] = 'example.com'
         MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'

--- a/pushmanager/tests/test_ui_modules.py
+++ b/pushmanager/tests/test_ui_modules.py
@@ -1,3 +1,4 @@
+
 import mock
 import testify as T
 from pushmanager.ui_modules import Request
@@ -22,7 +23,6 @@ class UIModuleTest(T.TestCase):
             T.assert_equals(gen_tags[0][1], None)
 
 
-
     def test_generate_tag_list_gitok(self):
         request = Request(StubHandler())
         request_info = {'tags':'git-ok', 'branch':'test'}
@@ -30,3 +30,48 @@ class UIModuleTest(T.TestCase):
         with mock.patch.dict(Settings, MockedSettings):
             gen_tags = request._generate_tag_list(request_info, 'repo')
             T.assert_equals(gen_tags[0][1], 'https://example.com/?p=repo.git;a=log;h=refs/heads/test')
+
+    @mock.patch('pushmanager.ui_modules.urllib2.urlopen')
+    def test_generate_test_tag_normal(self, mock_urlopen):
+        m = mock.Mock()
+        m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"url" : "www.example.com/results/sha"}']
+        mock_urlopen.return_value = m
+
+        MockedSettings['tests_tag']['tag'] = 'test'
+        MockedSettings['tests_tag']['tag_api_endpoint'] = 'example.com'
+        MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
+        MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
+        MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
+
+        request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
+        with mock.patch.dict(Settings, MockedSettings):
+            request = Request(StubHandler())
+            gen_tags = request._generate_tag_list(request_info, 'repo')
+            T.assert_equals(gen_tags[0], ("tag 0 fails",  "www.example.com/results/sha"))
+
+    @mock.patch('pushmanager.ui_modules.urllib2.urlopen')
+    def test_generate_test_tag_no_url(self, mock_urlopen):
+        m = mock.Mock()
+        m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"url" : ""}']
+        mock_urlopen.return_value = m
+
+        MockedSettings['tests_tag']['tag'] = 'test'
+        MockedSettings['tests_tag']['tag_api_endpoint'] = 'example.com'
+        MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
+        MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
+        MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
+
+        request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
+        with mock.patch.dict(Settings, MockedSettings):
+            request = Request(StubHandler())
+            gen_tags = request._generate_tag_list(request_info, 'repo')
+            T.assert_equals(gen_tags[0], ("tag 0 fails", None))
+
+    def test_generate_test_tag_none(self):
+        del MockedSettings['tests_tag']
+
+        request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
+        with mock.patch.dict(Settings, MockedSettings):
+            request = Request(StubHandler())
+            gen_tags = request._generate_tag_list(request_info, 'repo')
+            T.assert_equals(gen_tags[0][0], "test")

--- a/pushmanager/tests/test_ui_modules.py
+++ b/pushmanager/tests/test_ui_modules.py
@@ -1,4 +1,3 @@
-
 import mock
 import testify as T
 from pushmanager.ui_modules import Request
@@ -22,7 +21,6 @@ class UIModuleTest(T.TestCase):
             gen_tags = request._generate_tag_list(request_info, 'repo')
             T.assert_equals(gen_tags[0][1], None)
 
-
     def test_generate_tag_list_gitok(self):
         request = Request(StubHandler())
         request_info = {'tags':'git-ok', 'branch':'test'}
@@ -30,52 +28,3 @@ class UIModuleTest(T.TestCase):
         with mock.patch.dict(Settings, MockedSettings):
             gen_tags = request._generate_tag_list(request_info, 'repo')
             T.assert_equals(gen_tags[0][1], 'https://example.com/?p=repo.git;a=log;h=refs/heads/test')
-
-    @mock.patch('pushmanager.ui_modules.urllib2.urlopen')
-    def test_generate_test_tag_normal(self, mock_urlopen):
-        m = mock.Mock()
-        m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"id" : "123"}']
-        mock_urlopen.return_value = m
-
-        MockedSettings['tests_tag'] = {}
-        MockedSettings['tests_tag']['tag'] = 'test'
-        MockedSettings['tests_tag']['tag_api_endpoint'] = 'example.com'
-        MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
-        MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
-        MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
-        MockedSettings['tests_tag']['servername'] = 'www.example.com/%ID%'
-
-        request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
-        with mock.patch.dict(Settings, MockedSettings):
-            request = Request(StubHandler())
-            gen_tags = request._generate_tag_list(request_info, 'repo')
-            T.assert_equals(gen_tags[0], ("tag 0 fails",  "www.example.com/123"))
-
-    @mock.patch('pushmanager.ui_modules.urllib2.urlopen')
-    def test_generate_test_tag_no_url(self, mock_urlopen):
-        m = mock.Mock()
-        m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"url" : ""}']
-        mock_urlopen.return_value = m
-
-        MockedSettings['tests_tag'] = {}
-        MockedSettings['tests_tag']['tag'] = 'test'
-        MockedSettings['tests_tag']['tag_api_endpoint'] = 'example.com'
-        MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
-        MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
-        MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
-        MockedSettings['tests_tag']['servername'] = 'www.example.com/%ID$'
-
-        request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
-        with mock.patch.dict(Settings, MockedSettings):
-            request = Request(StubHandler())
-            gen_tags = request._generate_tag_list(request_info, 'repo')
-            T.assert_equals(gen_tags[0], ("tag 0 fails", None))
-
-    def test_generate_test_tag_none(self):
-        del MockedSettings['tests_tag']
-
-        request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
-        with mock.patch.dict(Settings, MockedSettings):
-            request = Request(StubHandler())
-            gen_tags = request._generate_tag_list(request_info, 'repo')
-            T.assert_equals(gen_tags[0][0], "test")

--- a/pushmanager/tests/test_ui_modules.py
+++ b/pushmanager/tests/test_ui_modules.py
@@ -34,7 +34,7 @@ class UIModuleTest(T.TestCase):
     @mock.patch('pushmanager.ui_modules.urllib2.urlopen')
     def test_generate_test_tag_normal(self, mock_urlopen):
         m = mock.Mock()
-        m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"url" : "www.example.com/results/sha"}']
+        m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"url" : "results/sha"}']
         mock_urlopen.return_value = m
 
         MockedSettings['tests_tag'] = {}
@@ -43,6 +43,7 @@ class UIModuleTest(T.TestCase):
         MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
         MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
         MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
+        MockedSettings['tests_tag']['servername'] = 'www.example.com'
 
         request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
         with mock.patch.dict(Settings, MockedSettings):
@@ -62,6 +63,7 @@ class UIModuleTest(T.TestCase):
         MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
         MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
         MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
+        MockedSettings['tests_tag']['servername'] = 'www.example.com'
 
         request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
         with mock.patch.dict(Settings, MockedSettings):

--- a/pushmanager/tests/test_ui_modules.py
+++ b/pushmanager/tests/test_ui_modules.py
@@ -34,7 +34,7 @@ class UIModuleTest(T.TestCase):
     @mock.patch('pushmanager.ui_modules.urllib2.urlopen')
     def test_generate_test_tag_normal(self, mock_urlopen):
         m = mock.Mock()
-        m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"url" : "results/sha"}']
+        m.read.side_effect = ['{"tag" : "tag 0 fails"}', '{"id" : "123"}']
         mock_urlopen.return_value = m
 
         MockedSettings['tests_tag'] = {}
@@ -43,13 +43,13 @@ class UIModuleTest(T.TestCase):
         MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
         MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
         MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
-        MockedSettings['tests_tag']['servername'] = 'www.example.com'
+        MockedSettings['tests_tag']['servername'] = 'www.example.com/%ID%'
 
         request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
         with mock.patch.dict(Settings, MockedSettings):
             request = Request(StubHandler())
             gen_tags = request._generate_tag_list(request_info, 'repo')
-            T.assert_equals(gen_tags[0], ("tag 0 fails",  "www.example.com/results/sha"))
+            T.assert_equals(gen_tags[0], ("tag 0 fails",  "www.example.com/123"))
 
     @mock.patch('pushmanager.ui_modules.urllib2.urlopen')
     def test_generate_test_tag_no_url(self, mock_urlopen):
@@ -63,7 +63,7 @@ class UIModuleTest(T.TestCase):
         MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
         MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
         MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
-        MockedSettings['tests_tag']['servername'] = 'www.example.com'
+        MockedSettings['tests_tag']['servername'] = 'www.example.com/%ID$'
 
         request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
         with mock.patch.dict(Settings, MockedSettings):

--- a/pushmanager/ui_modules.py
+++ b/pushmanager/ui_modules.py
@@ -104,9 +104,9 @@ class Request(UIModule):
                     result_api_url = Settings['tests_tag']['url_api_endpoint'].replace('%SHA%', request['revision'])
                     result_api_body = Settings['tests_tag']['url_api_body'].replace('%SHA%', request['revision'])
                     resp = urllib2.urlopen(result_api_url, result_api_body)
-                    results_url = json.loads(resp.read())['url']
-                    if results_url != '':
-                        tags[tests_tag] = results_url
+                    results_qstring = json.loads(resp.read())['url']
+                    if results_qstring != '':
+                        tags[tests_tag] = Settings['tests_tag']['servername'] + '/' + results_qstring
                 except Exception as e:
                     logging.warning(e)
                     logging.warning("Couldn't load results for results test URL from %s with body %s" %

--- a/pushmanager/ui_modules.py
+++ b/pushmanager/ui_modules.py
@@ -1,5 +1,8 @@
 import datetime
+import json
+import logging
 import os
+import urllib2
 
 from pushmanager.core import util
 from pushmanager.core.settings import Settings
@@ -62,11 +65,13 @@ class Request(UIModule):
 
         return self.render_string('modules/request.html', request=request, pretty_date=util.pretty_date, **kwargs)
 
+
     def _generate_tag_list(self, request, repo):
         tags = dict((tag, None) for tag in (request['tags'].split(',') if request['tags'] else []))
 
         if 'buildbot' in tags:
             tags['buildbot'] = "https://%s/rev/%s" % (Settings['buildbot']['servername'], request['revision'])
+
 
         if 'git-ok' in tags:
             tags['git-ok'] = 'https://%s/?p=%s.git;a=log;h=refs/heads/%s' % (
@@ -81,6 +86,38 @@ class Request(UIModule):
                 repo,
                 request['branch']
             )
+
+        if 'tests_tag' in Settings and Settings['tests_tag']['tag'] in tags:
+            tests_tag = Settings['tests_tag']['tag']
+            try:
+                api_url = Settings['tests_tag']['tag_api_endpoint'].replace('%SHA%', request['revision'])
+                api_body = Settings['tests_tag']['tag_api_body'].replace('%SHA%', request['revision'])
+                resp = urllib2.urlopen(api_url, api_body)
+                tests_tag = json.loads(resp.read())['tag']
+            except Exception as e:
+                tests_tag += ': ERROR retrieving'
+                logging.error(e)
+
+            tags[tests_tag] = None
+            if 'url_api_endpoint' in Settings['tests_tag']:
+                try:
+                    result_api_url = Settings['tests_tag']['url_api_endpoint'].replace('%SHA%', request['revision'])
+                    result_api_body = Settings['tests_tag']['url_api_body'].replace('%SHA%', request['revision'])
+                    resp = urllib2.urlopen(result_api_url, result_api_body)
+                    results_url = json.loads(resp.read())['url']
+                    if results_url != '':
+                        tags[tests_tag] = results_url
+                except Exception as e:
+                    logging.warning(e)
+                    logging.warning("Couldn't load results for results test URL from %s with body %s" %
+                            (
+                                Settings['tests_tag']['url_api_endpoint'].replace('%SHA%', request['revision']),
+                                Settings['tests_tag']['url_api_body'].replace('%SHA%', request['revision'])
+                            )
+                        )
+
+
+            del tags[Settings['tests_tag']['tag']]
 
         return sorted(tags.iteritems())
 

--- a/pushmanager/ui_modules.py
+++ b/pushmanager/ui_modules.py
@@ -104,9 +104,9 @@ class Request(UIModule):
                     result_api_url = Settings['tests_tag']['url_api_endpoint'].replace('%SHA%', request['revision'])
                     result_api_body = Settings['tests_tag']['url_api_body'].replace('%SHA%', request['revision'])
                     resp = urllib2.urlopen(result_api_url, result_api_body)
-                    results_qstring = json.loads(resp.read())['url']
-                    if results_qstring != '':
-                        tags[tests_tag] = Settings['tests_tag']['servername'] + '/' + results_qstring
+                    result_id = json.loads(resp.read())['id']
+                    if result_id != '':
+                        tags[tests_tag] = Settings['tests_tag']['servername'].replace('%ID%', result_id).replace('%SHA%', request['revision'])
                 except Exception as e:
                     logging.warning(e)
                     logging.warning("Couldn't load results for results test URL from %s with body %s" %


### PR DESCRIPTION
Allows for user to define a name and API endpoints for a dynamic tag that can be populated arbitrarily with test results for a request. Also allows for API endpoints so that the tag can link to a detailed results page of the tests.
