### PR TITLE
Always dynamically load test results in tests_tag

### DIFF
--- a/pushmanager/static/js/push.js
+++ b/pushmanager/static/js/push.js
@@ -513,12 +513,6 @@ $(function() {
         $('.tag-buildbot').each(function() { PushManager.Request.load_bb_failures(this); });
     }, 1000);
 
-    if ('tests_tag' in Settings) {
-        setTimeout(function() {
-            $('.tag-'+Settings['tests_tag']['tag']).each(function() { PushManager.Request.load_test_api_tags(this); });
-        }, 1000)
-    }
-
     $('#push-survey').dialog({
         autoOpen: false,
         modal: true,

--- a/pushmanager/templates/base.html
+++ b/pushmanager/templates/base.html
@@ -58,6 +58,11 @@ PushManager.current_user = "{% if current_user %}{{ escape(current_user) }}{% en
 </script>
 <script type="text/javascript">
 var Settings = {{ JSSettings_json }}
+if ('tests_tag' in Settings) {
+  setTimeout(function() {
+    $('.tag-'+Settings['tests_tag']['tag']).each(function() { PushManager.Request.load_test_api_tags(this); });
+  }, 1000)
+}
 </script>
 {% block scripts %}
 {% end %}


### PR DESCRIPTION
Currently, the results of the test suite are only displayed in /push. This will have them load on any page that has a template that inherits from base.html.
