### PR TITLE
Minor fixes and test runs for push branch

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -66,7 +66,7 @@ buildbot:
     servername: buildbot.mydomain.com
 
 # Set dynamic test tag using a REST api (http or https)
-# Request's SHA will replace %SHA%
+# Request's SHA will replace %SHA% and %BRANCH% will be replaced with branchname
 tests_tag:
     # User-added tag that will be replaced with api result
     tag: "test-framework"
@@ -79,7 +79,12 @@ tests_tag:
     url_api_endpoint: "http://example.com/api/v1/test_results_id"
     url_api_body: '{ "sha" : "%SHA%" }'
     # The run's ID from api will replace %ID% 
-    servername: "example.com/run/%SHA%/%ID%"
+    url_tmpl: "example.com/run/%SHA%/%ID%"
+
+    # Link template for url to results for push's branch
+    # (can only replace branch, not sha or id)
+    push_url_tmpl: "http://example.com/branch/%BRANCH%"
+    push_test_label: "Test Runs"
 
 # The string %TICKET% will be replaced by the ticket id
 ticket_tracker_url_format: "http://server:port/path/%TICKET%"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -73,9 +73,10 @@ tests_tag:
     # JSON 'tag' value from POST response of this URL will replace tag
     tag_api_endpoint: "http://example.com/api/v1/tests_tag"
     tag_api_body: '{ "sha" : "%SHA%" }'
+
     # If defined, tag will link to servername below and replace %ID%
     # with the 'id' field in the JSON returned by url_api
-    url_api_endpoint: "http://example.com/api/v1/test_results_url"
+    url_api_endpoint: "http://example.com/api/v1/test_results_id"
     url_api_body: '{ "sha" : "%SHA%" }'
     # The run's ID from api will replace %ID% 
     servername: "example.com/run/%SHA%/%ID%"

--- a/pushmanager/core/settings.py
+++ b/pushmanager/core/settings.py
@@ -38,9 +38,12 @@ JSSettings = {
         'main_repository': None,
     },
     'check_sites_bookmarklet': None,
+    'tests_tag': {
+        'tag': None,
+        'push_test_label': None,
+        'push_url_tmpl': None,
+    },
 }
-if 'tests_tag' in Settings:
-    JSSettings['tests_tag'] = {'tag': None}
 
 dict_copy_keys(to_dict=JSSettings, from_dict=Settings)
 

--- a/pushmanager/core/util.py
+++ b/pushmanager/core/util.py
@@ -206,7 +206,9 @@ def dict_copy_keys(to_dict, from_dict):
     that are present in to_dict
     """
     for key, value in to_dict.items():
-        if type(value) is dict:
+        if key not in from_dict:
+          del to_dict[key]
+        elif type(value) is dict:
             dict_copy_keys(value, from_dict[key])
         else:
             to_dict[key] = copy.deepcopy(from_dict[key])

--- a/pushmanager/servlets/testtag.py
+++ b/pushmanager/servlets/testtag.py
@@ -40,11 +40,14 @@ class TestTagServlet(RequestHandler):
             if 'url_api_endpoint' in Settings['tests_tag']:
                 try:
                     result_api_url = Settings['tests_tag']['url_api_endpoint'].replace('%SHA%', request['revision'])
+                    result_api_url = result_api_url.replace('%BRANCH%', request['branch'])
                     result_api_body = Settings['tests_tag']['url_api_body'].replace('%SHA%', request['revision'])
+                    result_api_body = result_api_body.replace('%BRANCH%', request['branch'])
                     resp = urllib2.urlopen(result_api_url, result_api_body)
                     result_id = url_escape(json.loads(resp.read())['id'])
                     if result_id != '':
-                        response['url'] = Settings['tests_tag']['servername'].replace('%ID%', result_id).replace('%SHA%', request['revision'])
+                        response['url'] = Settings['tests_tag']['url_tmpl'].replace('%ID%', result_id).replace('%SHA%', request['revision'])
+                        response['url'] = response['url'].replace('%BRANCH%', request['branch'])
                 except Exception as e:
                     logging.warning(e)
                     logging.warning("Couldn't load results for results test URL from %s with body %s" %

--- a/pushmanager/static/js/push.js
+++ b/pushmanager/static/js/push.js
@@ -95,7 +95,7 @@ $(function() {
                     "(?:[a-z]+,?\\s?)+" +   //   and one or more usernames (possibly separated by comma and/or a single space)
                 "\\))?" +                   //   followed by a )
             ",?\\s?" +                      // possibly followed by a command and space
-            ")+")                           // and more of the same
+            ")+", "i")                           // and more of the same
 
         var people = (people_pat.exec(contents) || [""])[0];
         PushManager.send_message_dialog(people);

--- a/pushmanager/templates/push-info.html
+++ b/pushmanager/templates/push-info.html
@@ -4,6 +4,12 @@
 	{% if push_info['stageenv'] %}<li><span class="label">Stage</span><span class="value">{{ escape(push_info['stageenv']) }}</span></li>{% end %}
 {% if push_info['state'] == 'accepting' %}
 	<li><span class="label">Buildbot Runs</span><span class="value"><a href="https://{{ escape(Settings['buildbot']['servername']) }}/branch/{{ escape(push_info['branch']) }}">url</a></span></li>
+  {% if 'tests_tag' in Settings and 'push_url_tmpl' in Settings['tests_tag'] %}
+    <li>
+      <span class="label">{{ Settings['tests_tag']['push_test_label'] }}</span>
+      <span class="value"><a href="{{ escape(Settings['tests_tag']['push_url_tmpl'].replace('%BRANCH%', push_info['branch'])) }}">url</a></span>
+    </li>
+  {% end %}
 {% end %}
 	<li><span class="label">State</span><span class="value"><ul class="tags">
 			<li class="tag-{{ escape(push_info['state']) }}">{{ escape(push_info['state']) }}</li>

--- a/pushmanager/tests/test_servlet_testtag.py
+++ b/pushmanager/tests/test_servlet_testtag.py
@@ -20,7 +20,7 @@ class TestTagServletTest(T.TestCase):
         MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
         MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
         MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
-        MockedSettings['tests_tag']['servername'] = 'www.example.com/%ID%'
+        MockedSettings['tests_tag']['url_tmpl'] = 'www.example.com/%ID%'
 
         request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
         with mock.patch.dict(Settings, MockedSettings):
@@ -39,7 +39,7 @@ class TestTagServletTest(T.TestCase):
         MockedSettings['tests_tag']['tag_api_body'] = '{ "sha" : "%SHA%" }'
         MockedSettings['tests_tag']['url_api_endpoint'] = "http://example.com/api/v1/test_results_url"
         MockedSettings['tests_tag']['url_api_body'] = '{ "sha" : "%SHA%" }'
-        MockedSettings['tests_tag']['servername'] = 'www.example.com/%ID$'
+        MockedSettings['tests_tag']['url_tmpl'] = 'www.example.com/%ID%'
 
         request_info = {'tags':'test', 'branch':'test', 'revision': 'abc123'}
         with mock.patch.dict(Settings, MockedSettings):

--- a/pushmanager/tests/test_template_push.py
+++ b/pushmanager/tests/test_template_push.py
@@ -78,6 +78,7 @@ class PushTemplateTest(TemplateTestCase):
             'Pushmaster': basic_push['user'],
             'Branch': basic_push['branch'],
             'Buildbot Runs': 'https://%s/branch/%s' % (Settings['buildbot']['servername'], basic_push['branch']),
+            'Test Runs': Settings['tests_tag']['push_url_tmpl'].replace("%BRANCH%",basic_push['branch']),
             'State': basic_push['state'],
             'Push Type': basic_push['pushtype'],
             'Created': time.strftime("%x %X", time.localtime(basic_push['created']))
@@ -303,7 +304,7 @@ class PushTemplateTest(TemplateTestCase):
         T.assert_equal(len(found_divs), 1)
 
     push_info_items = [
-        'Pushmaster', 'Branch', 'Buildbot Runs',
+        'Pushmaster', 'Branch', 'Buildbot Runs', 'Test Runs',
         'State', 'Push Type', 'Created', 'Modified'
     ]
 
@@ -327,6 +328,9 @@ class PushTemplateTest(TemplateTestCase):
             if li[0].text == 'Buildbot Runs':
                 T.assert_equal(li[1][0].text, 'url')
                 T.assert_equal(li[1][0].attrib['href'], push_info_items['Buildbot Runs'])
+            elif li[0].text == 'Test Runs':
+                T.assert_equal(li[1][0].text, 'url')
+                T.assert_equal(li[1][0].attrib['href'], push_info_items['Test Runs'])
             elif li[0].text == 'State':
                 T.assert_equal(li[1][0].attrib['class'], 'tags')  # Inner ul
                 T.assert_equal(li[1][0][0].attrib['class'], 'tag-%s' % push_info_items['State'])  # Inner li
@@ -374,6 +378,7 @@ class PushTemplateTest(TemplateTestCase):
         push_info_items = dict(self.basic_push_info_items)
         push_info_items['State'] = 'live'
         del push_info_items['Buildbot Runs']
+        del push_info_items['Test Runs']
 
         self.assert_push_info_listitems(list(tree.iter('ul'))[0], push_info_items)
         self.assert_push_info_attributes(list(tree.iter('ul'))[0].attrib, self.push_info_attributes)


### PR DESCRIPTION
Fixes in request: 
- case-insensitive on username regex for message all
- copy_dict for Settings ignores keys that are not in original dict

Push branches can include generic test run link at top of /push if defined in config.yaml
