### PR TITLE
Stop gzipping responses. Should be job of proxy.

### DIFF
--- a/pushmanager/pushmanager_api.py
+++ b/pushmanager/pushmanager_api.py
@@ -21,7 +21,6 @@ api_application = tornado.web.Application(
     # Server settings
     static_path = os.path.join(os.path.dirname(__file__), "static"),
     template_path = os.path.join(os.path.dirname(__file__), "templates"),
-    gzip = True,
     login_url = "/login",
     cookie_secret = Settings['cookie_secret'],
     ui_modules = ui_modules,

--- a/pushmanager/pushmanager_main.py
+++ b/pushmanager/pushmanager_main.py
@@ -115,7 +115,6 @@ class PushManagerApp(Application):
             # Server settings
             static_path = os.path.join(os.path.dirname(__file__), "static"),
             template_path = os.path.join(os.path.dirname(__file__), "templates"),
-            gzip = True,
             login_url = "/login",
             cookie_secret = Settings['cookie_secret'],
             ui_modules = ui_modules,


### PR DESCRIPTION
Pretty simple. Gzip takes time for no good reason. Shouldn't really be handled by tornado, but by apache2,  nginx, other proxy here, etc etc.
