### PR TITLE
Remove explicit finish call in checklist that will cause 500 errors

### DIFF
--- a/pushmanager/servlets/checklist.py
+++ b/pushmanager/servlets/checklist.py
@@ -117,4 +117,4 @@ class ChecklistToggleServlet(RequestHandler):
 
         query = db.push_checklist.update().where(
             db.push_checklist.c.id == self.checklist).values({'complete': new_value})
-        db.execute_cb(query, lambda _, __:self.finish())
+        db.execute_cb(query, lambda _, __:None)


### PR DESCRIPTION
Since this function is not asynchronous, it is not necessary to call self.finish (it will be called when the post() returns). Doing so allows for the possibility of calling finish 2 times, which raises an exception and potentially throws a 500 error.
