### PR TITLE
Daemon updates SHA of active requests & reruns conflict checks

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -32,6 +32,7 @@ from pushmanager.core.util import del_from_tags_str
 from pushmanager.core.util import EscapedDict
 from pushmanager.core.util import tags_contain
 from pushmanager.core.xmppclient import XMPPQueue
+from sqlalchemy import or_
 from tornado.escape import xhtml_escape
 
 
@@ -291,7 +292,7 @@ class GitQueueTask(object):
     - TEST_PICKME_CONFLICT: check which (if any) branches also pickme'd for the
         same push cause merge conflicts with this branch
     - TEST_ALL_PICKMES: Takes a push id, and queues every pushme with
-        TEST_PICKME_CONFLICT. Used when an item is de-pickmed to ensure that
+    - TEST_CONFLICTING_PICKMES. Used when an item is de-pickmed to ensure that
         anything it might have conlficted with is unmarked
     """
 
@@ -392,6 +393,11 @@ class GitQueue(object):
         cls.sha_worker_process.daemon = True
         cls.sha_worker_process.start()
         worker_pids.append(cls.sha_worker_process.pid)
+
+        cls.check_sha_worker_proc = Process(target=cls.check_active_request_shas, name='git-branch-sha-updater-daemon')
+        cls.check_sha_worker_proc.daemon = True
+        cls.check_sha_worker_proc.start()
+        worker_pids.append(cls.check_sha_worker_proc.pid)
 
         return worker_pids
 
@@ -560,7 +566,7 @@ class GitQueue(object):
         return repository
 
     @classmethod
-    def _get_branch_sha_from_repo(cls, req):
+    def _get_branch_sha_from_repo(cls, req, alert=True):
         user_to_notify = req['user']
         query_details = {
             'user': req['user'],
@@ -600,7 +606,8 @@ class GitQueue(object):
             query_details['stderr'] = e.giterr
             msg %= EscapedDict(query_details)
             subject = '[push error] %s - %s' % (req['user'], req['title'])
-            MailQueue.enqueue_user_email([user_to_notify], msg, subject)
+            if alert:
+                MailQueue.enqueue_user_email([user_to_notify], msg, subject)
             return None
 
         # successful ls-remote, build up the refs list
@@ -630,7 +637,8 @@ class GitQueue(object):
             """)
         msg %= EscapedDict(query_details)
         subject = '[push error] %s - %s' % (req['user'], req['title'])
-        MailQueue.enqueue_user_email([user_to_notify], msg, subject)
+        if alert:
+            MailQueue.enqueue_user_email([user_to_notify], msg, subject)
         return None
 
     @classmethod
@@ -1307,6 +1315,58 @@ class GitQueue(object):
             )
 
     @classmethod
+    def _notify_updated_request_sha(cls, updated_req, new_sha):
+        msg  = """
+                <p>
+                    Your open request for the merging of branch %(branch)s has been updated
+                </p>
+                <p>
+                    <strong>%(user)s - %(title)s</strong><br />
+                    <em>%(repo)s/%(branch)s</em>
+                </p>
+                <p>
+                    Old SHA of branch's head: %(revision)s<br/>
+                    New SHA of branch's head: %(new_sha)s
+                </p>
+                <p>
+                    Regards,<br/>
+                    PushManager
+                </p>
+                """
+        repl_dict = {
+                'branch' : updated_req['branch'],
+                'user' : updated_req['user'],
+                'title' : updated_req['title'],
+                'repo' : updated_req['repo'],
+                'revision' : updated_req['revision'],
+                'new_sha' : new_sha
+                }
+        msg %= repl_dict
+        subject = '[push] %s - %s' % (updated_req['user'], updated_req['title'])
+        user_to_notify = updated_req['user']
+        MailQueue.enqueue_user_email([user_to_notify], msg, subject)
+        return
+
+    @classmethod
+    def _get_active_requests(cls):
+        result = [None]
+
+        def on_db_return(success, db_results):
+            assert success, "Database error."
+            result[0] = db_results.fetchall()
+            db_results.close()
+
+        req_active_query = db.push_requests.select(or_(
+            db.push_requests.c.state == 'requested',
+            db.push_requests.c.state == 'pickme',
+            db.push_requests.c.state == 'added')
+        )
+
+        db.execute_cb(req_active_query, on_db_return)
+        reqs = result[0]
+        return reqs
+
+    @classmethod
     def process_sha_queue(cls):
         logging.info("Starting GitConflictQueue")
         while True:
@@ -1361,6 +1421,54 @@ class GitQueue(object):
                 logging.error('THREAD ERROR:', exc_info=True)
             finally:
                 cls.conflict_queue.task_done()
+
+    @classmethod
+    def check_active_request_shas(cls):
+        while True:
+            time.sleep(1) #Throttle a bit
+            active_requests = cls._get_active_requests()
+
+            if active_requests is None:
+                continue
+
+            for req in active_requests:
+                time.sleep(.04) # Try not to hammer the git repo
+                sha = cls._get_branch_sha_from_repo(req, alert=False)
+                if sha is None or cls.request_is_excluded_from_git_verification(req):
+                    continue
+                if not req['branch'] or not req['revision']:
+                    continue
+                if sha == req['revision']:
+                    continue
+                try:
+                    cls._update_req_sha_and_queue_pickme(req, sha)
+                    cls._notify_updated_request_sha(req, sha)
+                except Exception as e:
+                    logging.error('THREAD ERROR: %s' % (e))
+
+    @classmethod
+    def _update_req_sha_and_queue_pickme(cls, req, sha):
+        logging.info("Updating: %s request's sha from %s to %s" % (req['title'], req['revision'], sha))
+        updated_sha = {'revision': sha}
+        updated_request = cls._update_request(req, updated_sha)
+        if not updated_request:
+            raise Exception("Failed to update pickme"
+                            "%s request's sha from %s to %s" % (req['title'], req['revision'], sha))
+        if req['state'] in ('pickme', 'added'):
+            if  'no-conflicts' in req['tags'] or 'conflict-master' in req['tags']:
+                GitQueue.enqueue_request(
+                    GitTaskAction.TEST_PICKME_CONFLICT,
+                    req['id'],
+                    # TODO: No way to use proxy URL in daemon. Make URL prettier eventually
+                    pushmanager_url='https://%s:%s' % (Settings['main_app']['servername'], Settings['main_app']['port'])
+                )
+            elif 'conflict-pickme' in req['tags']:
+                GitQueue.enqueue_request(
+                    GitTaskAction.TEST_CONFLICTING_PICKMES,
+                    cls._get_push_for_request(req['id'])['push'],
+                    # TODO: No way to use proxy URL in daemon. Make URL prettier eventually
+                    pushmanager_url='https://%s:%s' % (Settings['main_app']['servername'], Settings['main_app']['port'])
+                )
 
     @classmethod
     def enqueue_request(cls, task_type, request_id, **kwargs):

--- a/pushmanager/tests/test_core_git.py
+++ b/pushmanager/tests/test_core_git.py
@@ -733,6 +733,73 @@ class CoreGitTest(T.TestCase):
 
         T.assert_raises(GitException, pushmanager.core.git._stale_submodule_check, repo_path)
 
+    def test_update_req_sha_and_queue_pickme_requested(self):
+        new_sha = "1"*40
+        request = copy.deepcopy(self.fake_request)
+        request['state'] = 'requested'
+        with mock.patch('pushmanager.core.git.GitQueue.enqueue_request') as enqueue_req:
+            GitQueue._update_req_sha_and_queue_pickme(request, new_sha)
+
+            result = [None]
+            def on_db_return(success, db_results):
+                assert success, "Database error"
+                result[0] = db_results.first()
+
+            request_info_query = db.push_requests.select().where(
+                db.push_requests.c.id == self.fake_request['id']
+            )
+            db.execute_cb(request_info_query, on_db_return)
+            T.assert_false(enqueue_req.called)
+            T.assert_equal(result[0][5], new_sha)
+
+    def test_update_req_sha_and_queue_pickme_pickme_test_pickme_conflict(self):
+        new_sha = "1"*40
+        pickme_request = copy.deepcopy(self.fake_request)
+        pickme_request['state'] = 'pickme'
+        pickme_request['tags'] = 'no-conflicts'
+        with mock.patch('pushmanager.core.git.GitQueue.enqueue_request') as enqueue_req:
+            GitQueue._update_req_sha_and_queue_pickme(pickme_request, new_sha)
+
+            result = [None]
+            def on_db_return(success, db_results):
+                assert success, "Database error"
+                result[0] = db_results.first()
+
+            request_info_query = db.push_requests.select().where(
+                db.push_requests.c.id == self.fake_request['id']
+            )
+            db.execute_cb(request_info_query, on_db_return)
+            T.assert_equal(result[0][5], new_sha)
+            enqueue_req.assert_has_calls([
+                mock.call(GitTaskAction.TEST_PICKME_CONFLICT, 1,
+                          pushmanager_url='https://%s:%s' % (MockedSettings['main_app']['servername'], MockedSettings['main_app']['port']))
+            ])
+
+    def test_update_req_sha_and_queue_pickme_added_test_conflicting_pickmes(self):
+        new_sha = "1"*40
+        pickme_request = copy.deepcopy(self.fake_request)
+        pickme_request['state'] = 'added'
+        pickme_request['tags'] = 'conflict-pickme'
+        with mock.patch('pushmanager.core.git.GitQueue.enqueue_request') as enqueue_req:
+            GitQueue._update_req_sha_and_queue_pickme(pickme_request, new_sha)
+
+            result = [None]
+            def on_db_return(success, db_results):
+                assert success, "Database error"
+                result[0] = db_results.first()
+
+            request_info_query = db.push_requests.select().where(
+                db.push_requests.c.id == self.fake_request['id']
+            )
+            db.execute_cb(request_info_query, on_db_return)
+            T.assert_equal(result[0][5], new_sha)
+            enqueue_req.assert_has_calls([
+                mock.call(
+                    GitTaskAction.TEST_CONFLICTING_PICKMES,
+                    GitQueue._get_push_for_request(pickme_request['id'])['push'],
+                    pushmanager_url='https://%s:%s' % (MockedSettings['main_app']['servername'], MockedSettings['main_app']['port']))
+            ])
+
     def test_stderr_and_stdout_in_conflict_text(self):
         welsh_req = {'id': 2, 'user': 'test', 'user': 'test', 'tags':'git-ok', 'title':'Welsh', 'repo':'.', 'branch':'change_welsh'}
         with nested(


### PR DESCRIPTION
Updates the sha of any requested, pickme or added branch if the ls-remote sha has changed since the request was made. Emails the request's user of the change of sha.

Will correctly rerun conflict checkers to determine if any new conflicts have arisen or if any conflicts have been resolved.
