### PR TITLE
git merge --no-rebase in case git global has been set to rebase on merge

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -422,6 +422,7 @@ class GitQueue(object):
             "pull",
             "--no-ff",
             "--no-commit",
+            "--no-rebase",
             pickme_request['repo'],
             pickme_request['branch'],
             cwd=master_repo_path)


### PR DESCRIPTION
When checking for conflicts, pushmanager attempts to merge branches and expects the merge to be a  traditional merge. If git global config is set to merge with rebase, then it fails and always detects conflict-master. Adding --no-rebase flag forces it to always behave the way it expects.
