### PR TITLE
Release Candidate: 0.3.12   2014-12-02

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,26 @@
+0.3.12   2014-12-02
+
+ IMPROVEMENTS
+
+ * Dynamic test tag loads on all pages now (kkellyy, #129)
+ * Pushes can now include link to generic test runs of themselves (kkellyy, #130)
+ * testtag servlet is now more robust:
+   404s on no id param and is asynchronous (kkellyy, #133)
+ * Automatically detect and update SHA of request branches, notify the request's
+   user and re-check for git conflicts if in pickme/added state (kkellyy, #134, #137)
+
+ BUG FIXES
+
+ * copy_dict in core/util now ignores keys not defined in original dict (kkellyy, #130)
+ * Pushmaster message users no longer case-sensitive (kkellyy, #130)
+ * checklist servlet no longer generates spurious 500s (kkellyy, #132)
+ * Explicitly add --no-rebase on git merge conflict testing to guaranteed
+   git behvaior (kkellyy, #135)
+
+ DEPRECATED
+
+ * No longer gzip responses by default. (kkellyy, #131)
+
 0.3.11   2014-11-12
 
  IMPROVEMENTS

--- a/pushmanager/__about__.py
+++ b/pushmanager/__about__.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 3, 11)
+__version_info__ = (0, 3, 12)
 __version__ = '%d.%d.%d' % __version_info__


### PR DESCRIPTION
0.3.12   2014-12-02

 IMPROVEMENTS
- Dynamic test tag loads on all pages now (kkellyy, #129)
- Pushes can now include link to generic test runs of themselves (kkellyy, #130)
- testtag servlet is now more robust:
  404s on no id param and is asynchronous (kkellyy, #133)
- Automatically detect and update SHA of request branches, notify the request's
  user and re-check for git conflicts if in pickme/added state (kkellyy, #134, #137)
  
  BUG FIXES
- copy_dict in core/util now ignores keys not defined in original dict (kkellyy, #130)
- Pushmaster message users no longer case-sensitive (kkellyy, #130)
- checklist servlet no longer generates spurious 500s (kkellyy, #132)
- Explicitly add --no-rebase on git merge conflict testing to guaranteed
  git behvaior (kkellyy, #135)
  
  DEPRECATED
- No longer gzip responses by default. (kkellyy, #131)
