### PR TITLE
Fix non-equality request id check

### DIFF
--- a/pushmanager/core/git.py
+++ b/pushmanager/core/git.py
@@ -494,7 +494,7 @@ class GitQueue(object):
                 add_remote.run()
             except GitException, e:
                 # If the remote already exists, git will return err 128
-                if e.gitret is 128:
+                if e.gitret == 128:
                     pass
                 else:
                     raise e
@@ -1171,7 +1171,7 @@ class GitQueue(object):
         if (
             duplicate_req and 'state' in duplicate_req
             and not duplicate_req['state'] == "discarded"
-            and duplicate_req['id'] is not req['id']
+            and duplicate_req['id'] != req['id']
         ):
             error_msg = "Git queue worker found another request with the same revision sha (ids %s and %s)" % (
                 duplicate_req['id'],

--- a/pushmanager/tests/test_core_git.py
+++ b/pushmanager/tests/test_core_git.py
@@ -43,7 +43,7 @@ class CoreGitTest(T.TestCase):
             'user': 'testuser',
             'tags': 'super-safe,logs',
             'revision': "0"*40,
-            'reviewid': 1,
+            'reviewid': 9001,
             'state': 'requested',
             'repo': 'testuser',
             'branch': 'super_safe_fix',


### PR DESCRIPTION
'is not' is incorrect when request id > 256 (value changes from small int to object). Previously wasn't an issue, since one didn't normally verify a branch more than once, but now with the new daemon, this happens frequently and can cause spurious duplicate request verify failures.
