### PR TITLE
Relase 0.3.14

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+0.3.14   2014-12-05
+
+ BUG FIXES
+
+ * Equality comparison for duplicate branches is != instead of 'is not'
+   so it doesn't do object comparisons for request ids > 256 (kkellyy, #139)
+
 0.3.13   2014-12-02
 
  BUG FIXES

--- a/pushmanager/__about__.py
+++ b/pushmanager/__about__.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 3, 13)
+__version_info__ = (0, 3, 14)
 __version__ = '%d.%d.%d' % __version_info__


### PR DESCRIPTION
 BUG FIXES
- Equality comparison for duplicate branches is != instead of 'is not'
  so it doesn't do object comparisons for request ids > 256 (kkellyy, #139)
