### PR TITLE
Allow for empty aliases

### DIFF
--- a/pushmanager/core/xmppclient.py
+++ b/pushmanager/core/xmppclient.py
@@ -53,7 +53,9 @@ class XMPPQueue(object):
         recipient, message = msg
 
         # Apply alias mapping, if any exists
-        recipient = Settings['aliases'].get(recipient, recipient)
+        aliases = Settings['aliases']
+        if aliases:
+            recipient = aliases.get(recipient, recipient)
 
         xmpp_message = xmpp.protocol.Message(recipient, message)
         try:

--- a/pushmanager/tests/test_core_xmppclient.py
+++ b/pushmanager/tests/test_core_xmppclient.py
@@ -64,6 +64,20 @@ class CoreXMPPClientTest(T.TestCase):
             T.assert_equal(pushmanager.core.xmppclient.XMPPQueue.message_queue.put.call_count, 0)
             T.assert_equal(pushmanager.core.xmppclient.XMPPQueue.message_queue.task_done.call_count, 1)
 
+    def test_process_queue_item_no_alias(self):
+        with nested(
+            mock.patch("%s.pushmanager.core.xmppclient.xmpp.Message" % __name__),
+            mock.patch("%s.pushmanager.core.xmppclient.XMPPQueue.message_queue" % __name__)
+        ):
+            MockedSettings['aliases'] = None
+            with mock.patch.dict(pushmanager.core.xmppclient.Settings, MockedSettings):
+                jabber_client = mock.MagicMock()
+                pushmanager.core.xmppclient.XMPPQueue.message_queue.configure_mock(**self.fake_queue_attrs)
+
+                pushmanager.core.xmppclient.XMPPQueue._process_queue_item(jabber_client)
+
+                T.assert_equal(jabber_client.send.call_count, 1)
+
     def test_process_queue_item_retry(self):
         def raise_ioerror(*args):
             raise IOError("Fake IOError")


### PR DESCRIPTION
YAML doesn't support empty hashes

If `aliases` is given no hash, the xmpp client will throw an error:

  File "./pushmanager/core/xmppclient.py", line 56, in
  _process_queue_item
      recipient = Settings['aliases'].get(recipient, recipient)
      AttributeError: 'NoneType' object has no attribute 'get'
