### PR TITLE
Notifyonly

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -55,6 +55,7 @@ xmpp:
     server: "xmpp_server"
     username: "someone@example.com"
     password: "abc123"
+    notifyonly: []
 
 # ReviewBoard instance
 reviewboard:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -47,6 +47,7 @@ mail:
     # Email address to send copies of all outgoing email to
     notifyall:
         - "push-updates@example.com"
+    notifyonly: []
 
 # Credentials for XMPP notifications
 xmpp:

--- a/pushmanager/core/mail.py
+++ b/pushmanager/core/mail.py
@@ -49,6 +49,15 @@ class MailQueue(object):
         msg = email.mime.text.MIMEText(message, 'html')
         msg['Subject'] = subject
         msg['From'] = from_email
+
+        notifyonly = Settings['mail']['notifyonly']
+        if notifyonly:
+            msg['To'] = ', '.join(notifyonly)
+            msg.set_payload('Original recipients: %s\n\n%s' % (recipient, msg.get_payload()))
+            cls.smtp.sendmail(from_email, notifyonly, msg.as_string())
+            cls.message_queue.task_done()
+            return
+
         msg['To'] = recipient
         cls.smtp.sendmail(from_email, [recipient], msg.as_string())
         other_recipients = set(Settings['mail']['notifyall']) - set([recipient])

--- a/pushmanager/core/xmppclient.py
+++ b/pushmanager/core/xmppclient.py
@@ -137,15 +137,21 @@ class XMPPQueue(object):
             raise ValueError('Recipient(s) must be a string or iterable of strings')
 
     @classmethod
-    def enqueue_user_xmpp(cls, recipients, *args, **kwargs):
+    def enqueue_user_xmpp(cls, recipients, message):
         """Transforms a list of 'user' to 'user@default_domain', then invokes enqueue_xmpp."""
         domain = Settings['xmpp']['default_domain']
+
         if isinstance(recipients, (list,set,tuple)):
             recipients = ['%s@%s' % (recepient, domain) if '@' not in recepient else recepient for recepient in recipients]
         elif isinstance(recipients, (str,unicode)):
             recipients = '%s@%s' % (recipients, domain) if '@' not in recipients else recipients
         else:
             raise ValueError('Recipient(s) must be a string or iterable of strings')
-        return cls.enqueue_xmpp(recipients, *args, **kwargs)
+
+        notifyonly = Settings['xmpp']['notifyonly']
+        if notifyonly:
+            message = "Original recipients: %s\n\n%s" % (recipients, message)
+            recipients = ['%s@%s' % (recepient, domain) if '@' not in recepient else recepient for recepient in notifyonly]
+        return cls.enqueue_xmpp(recipients, message)
 
 __all__ = ['XMPPQueue']

--- a/pushmanager/tests/test_core_mail.py
+++ b/pushmanager/tests/test_core_mail.py
@@ -1,18 +1,46 @@
+import copy
 import mock
-import pushmanager.core.mail
 import testify as T
+
+from pushmanager.core.settings import Settings
+import pushmanager.core.mail
 
 
 class MailQueueTest(T.TestCase):
 
-    def test_send_mail(self):
+    @T.setup_teardown
+    def mock_smtp(self):
         with mock.patch.object(pushmanager.core.mail.MailQueue, "smtp") as mocked_smtp:
             with mock.patch.object(pushmanager.core.mail.MailQueue, "message_queue"):
-                recipient = "test@test.com"
-                message = "test message"
-                subject = "test subject"
-                from_email = "fromtest@test.com"
+                self.mocked_smtp = mocked_smtp
+                self.MockedSettings = copy.deepcopy(Settings)
+                yield
 
-                pushmanager.core.mail.MailQueue._send_email(recipient, message, subject, from_email)
+    def test_send_mail(self):
+        recipient = "test@test.com"
+        message = "test message"
+        subject = "test subject"
+        from_email = "fromtest@test.com"
 
-                T.assert_equal(mocked_smtp.sendmail.called, True)
+        pushmanager.core.mail.MailQueue._send_email(recipient, message, subject, from_email)
+
+        T.assert_equal(self.mocked_smtp.sendmail.called, True)
+        self.mocked_smtp.sendmail.assert_any_call(from_email, [recipient], mock.ANY)
+        self.mocked_smtp.sendmail.assert_any_call(from_email, self.MockedSettings['mail']['notifyall'], mock.ANY)
+
+    def test_mail_notifyonly(self):
+        self.MockedSettings['mail']['notifyonly'] = [ 'notifyme', 'notifyyou', 'notifyhim', 'notifyher' ]
+        with mock.patch.dict(Settings, self.MockedSettings):
+            recipient = "test@test.com"
+            message = "test message"
+            subject = "test subject"
+            from_email = "fromtest@test.com"
+
+            pushmanager.core.mail.MailQueue._send_email(recipient, message, subject, from_email)
+
+            T.assert_equal(self.mocked_smtp.sendmail.called, True)
+            self.mocked_smtp.sendmail.assert_called_once_with(from_email, self.MockedSettings['mail']['notifyonly'], mock.ANY)
+
+            args = self.mocked_smtp.sendmail.call_args_list[0][0]
+            body = "Original recipients: %s\n\n%s" % (recipient, message)
+            T.assert_equal(args[2].endswith(body), True)


### PR DESCRIPTION
Allow mail and xmpp to be funneled to a specific list of users. This is useful in testing environments to avoid notifying users while using production-like data.
