### PR TITLE
Strip branch names for new push created.

### DIFF
--- a/pushmanager/servlets/newpush.py
+++ b/pushmanager/servlets/newpush.py
@@ -51,7 +51,7 @@ class NewPushServlet(RequestHandler):
         insert_query = db.push_pushes.insert({
             'title': self._arg('push-title'),
             'user': self.current_user,
-            'branch': self._arg('push-branch'),
+            'branch': self._arg('push-branch').strip(),
             'revision': "0"*40,
             'created': time.time(),
             'modified': time.time(),

--- a/pushmanager/tests/test_servlet_newpush.py
+++ b/pushmanager/tests/test_servlet_newpush.py
@@ -39,7 +39,7 @@ class NewPushServletTest(T.TestCase, ServletTestMixin):
                 branch = "jblack"
                 push_type = "regular"
 
-                uri = "/newpush?push-title=%s&branch=%s&push-type=%s" % (
+                uri = "/newpush?push-title=%s&push-branch=%s&push-type=%s" % (
                     title, branch, push_type
                 )
 
@@ -69,6 +69,33 @@ class NewPushServletTest(T.TestCase, ServletTestMixin):
                     mock.ANY, # channel
                     mock.ANY, # msg
                 ])
+
+
+    def test_removed_trailing_whitespace_in_branch_name(self):
+        def on_db_return(success, db_results):
+            assert success
+            pushes.extend(db_results.fetchall())
+
+        with nested(
+            mock.patch.dict(db.Settings, MockedSettings),
+            mock.patch.object(NewPushServlet, "get_current_user", return_value = "jblack"),
+            mock.patch.object(NewPushServlet, "redirect"),
+            mock.patch.object(MailQueue, "enqueue_user_email"),
+        ):
+            with mock.patch("%s.pushmanager.servlets.newpush.subprocess.call" % __name__):
+                title = "BestPushInTheWorld"
+                branch = "%20branch-name-with-whitespaces%20"
+                push_type = "regular"
+
+                self.fetch(
+                    "/newpush?push-title=%s&push-branch=%s&push-type=%s" % (
+                        title, branch, push_type
+                    )
+                )
+
+                pushes = []
+                db.execute_cb(db.push_pushes.select(), on_db_return)
+                T.assert_equal('branch-name-with-whitespaces', pushes[-1]['branch'])
 
 
 


### PR DESCRIPTION
Fixes #107 - branch names with whitespaces when new pushes are created.
