### PR TITLE
Add state filter to pushes view, fix pagination

### DIFF
--- a/pushmanager/servlets/pushes.py
+++ b/pushmanager/servlets/pushes.py
@@ -11,22 +11,29 @@ class PushesServlet(RequestHandler):
     @tornado.gen.engine
     def get(self):
         pushes_per_page = pushmanager.core.util.get_int_arg(self.request, 'rpp', 50)
-        before = pushmanager.core.util.get_int_arg(self.request, 'before', 0)
+        offset = pushmanager.core.util.get_int_arg(self.request, 'offset', 0)
+        state = pushmanager.core.util.get_str_arg(self.request, 'state', '')
         response = yield tornado.gen.Task(
-                        self.async_api_call,
-                        "pushes",
-                        {"rpp": pushes_per_page, "before": before}
-                    )
+            self.async_api_call,
+            'pushes',
+            {
+                'rpp': pushes_per_page,
+                'offset': offset,
+                'state': state,
+            }
+        )
 
         results = self.get_api_results(response)
         if not results:
             self.finish()
 
-        pushes, last_push = results
+        pushes, pushes_count = results
         self.render(
             "pushes.html",
             page_title="Pushes",
             pushes=pushes,
+            offset=offset,
             rpp=pushes_per_page,
-            last_push=last_push
+            state=state,
+            pushes_count=pushes_count,
         )

--- a/pushmanager/templates/pushes.html
+++ b/pushmanager/templates/pushes.html
@@ -10,6 +10,16 @@ Please remember to run all deployment branches on <strong>bb8</strong> and <stro
 	<li><button id="expand-pushes">Expand All</button></li>
 	<li><button id="collapse-pushes">Collapse All</button></li>
 	&mdash;
+	<li>
+		Show states:
+		<select id="state-filter">
+			<option value="">All states</option>
+			<option value="accepting" {% if state == 'accepting' %}selected="selected"{% end %}>Accepting</option>
+			<option value="live" {% if state == 'live' %}selected="selected"{% end %}>Live</option>
+			<option value="discarded" {% if state == 'discarded' %}selected="selected"{% end %}>Discarded</option>
+		</select>
+	</li>
+	&mdash;
 	<li><button id="new-push">New Push</button></li>
 	&mdash;
 	<li>{{ modules.NewRequestDialog() }}</li>
@@ -66,11 +76,11 @@ Please remember to run all deployment branches on <strong>bb8</strong> and <stro
 </ul>
 
 <div id="paginator">
-	{% if pushes and pushes[0]['id'] < last_push %}
-		<a href="/pushes?rpp={{ rpp }}&amp;before={{ pushes[0]['id'] + rpp + 1 }}"> Newer</a>
+	{% if pushes and offset > 0 %}
+		<a href="/pushes?rpp={{ rpp }}&amp;offset={{ max(offset - rpp, 0) }}&amp;state={{ url_escape(state) }}"> Newer</a>
 	{% end if %}
-	{% if pushes and pushes[-1]['id'] > 1 %}
-		<a href="/pushes?rpp={{ rpp }}&amp;before={{ pushes[-1]['id'] }}">Older</a>
+	{% if pushes and offset + rpp < pushes_count %}
+		<a href="/pushes?rpp={{ rpp }}&amp;offset={{ offset + rpp }}&amp;state={{ url_escape(state) }}">Older</a>
 	{% end if %}
 </div>
 
@@ -137,6 +147,14 @@ $(function() {
 		} else {
 			that.text("→");
 		}
+	});
+
+    $('#state-filter').change(function() {
+		var that = $(this);
+		var base_url = window.location.href.split('?')[0];
+		var new_state = encodeURIComponent(that.val());
+		var new_url = base_url + '?state=' + new_state;
+		window.location.href = new_url;
 	});
 });
 </script>

--- a/pushmanager/tests/test_servlet_api.py
+++ b/pushmanager/tests/test_servlet_api.py
@@ -44,8 +44,8 @@ class APITests(T.TestCase, ServletTestMixin, FakeDataMixin):
         pushes, last_push = self.api_call("pushes?rpp=1")
         T.assert_length(pushes, 1)
 
-        pushes, last_push = self.api_call("pushes?before=%d" % time.time())
-        T.assert_length(pushes, 2)
+        pushes, last_push = self.api_call("pushes?offset=1")
+        T.assert_length(pushes, 1)
 
     def test_pushes_order(self):
         self.insert_pushes()
@@ -60,6 +60,13 @@ class APITests(T.TestCase, ServletTestMixin, FakeDataMixin):
                 elif lastpush['state'] != 'accepting':
                     T.assert_gte(push['modified'], lastpush['modified'])
             lastpush = push
+
+    def test_pushes_state_filter(self):
+        self.insert_pushes()
+        pushes, last_push = self.api_call("pushes?state=live")
+        T.assert_length(pushes, 1)
+        for push in pushes:
+            T.assert_equal(push['state'], 'live')
 
     def test_pushcontents(self):
         pushcontents = self.api_call("pushcontents?id=1")

--- a/pushmanager/tests/test_template_pushes.py
+++ b/pushmanager/tests/test_template_pushes.py
@@ -8,13 +8,14 @@ class PushesTemplateTest(TemplateTestCase):
     pushes_page = 'pushes.html'
     new_push_page = 'new-push.html'
 
-    def render_pushes_page(self, page_title='Pushes', pushes=[], pushes_per_page=50, last_push=None):
+    def render_pushes_page(self, page_title='Pushes', pushes=[], pushes_per_page=50, offset=0):
         return self.render_etree(
             self.pushes_page,
             page_title=page_title,
             pushes=pushes,
             rpp=pushes_per_page,
-            last_push=last_push
+            offset=offset,
+            state='',
         )
 
     def test_include_new_push(self):


### PR DESCRIPTION
This pull request is split off from #152 and implements a state filter for the pushes view as well as fixing pagination by changing it to be offset-based. You can see from the test change I did that the 'before' variable I removed was once supposed to be a timestamp, but now the code uses it to pass around IDs.
