### PR TITLE
Add a few typical characters to the notify regex

### DIFF
--- a/pushmanager/static/js/push.js
+++ b/pushmanager/static/js/push.js
@@ -90,9 +90,9 @@ $(function() {
         var contents = $(this).siblings('.item-count').text();
 
         var people_pat = new RegExp(    // person, person (person, person), person (person), person
-            "(?:[a-z]+" +                   // A username, possibly followed by
+            "(?:[a-z0-9_\-\^|]+" +                   // A username, possibly followed by
                 "(?:\\s\\(" +               //   a space and (
-                    "(?:[a-z]+,?\\s?)+" +   //   and one or more usernames (possibly separated by comma and/or a single space)
+                    "(?:[a-z0-9_\-\^|]+,?\\s?)+" +   //   and one or more usernames (possibly separated by comma and/or a single space)
                 "\\))?" +                   //   followed by a )
             ",?\\s?" +                      // possibly followed by a command and space
             ")+", "i")                           // and more of the same


### PR DESCRIPTION
Just a small update to the regex for notifyall. Currently, it breaks for anyone with characters or other non-alphabetical characters. This isn't comprehensive, but it will catch some of the most common ones.
