### PR TITLE
changed command-to-run to text area

### DIFF
--- a/pushmanager/templates/push-dialogs.html
+++ b/pushmanager/templates/push-dialogs.html
@@ -1,7 +1,7 @@
 <div id="dialog-prototypes" style="display: none;">
 <!-- "Run a command" dialog -->
 	<div id="run-a-command">
-		<pre id="command-to-run">&nbsp;</pre>
+		<textarea id="command-to-run" cols="50" readonly>&nbsp;</textarea>
 		<p class="directions">
 			Wait for it to complete, then
 			<button id="command-done">Continue</button>


### PR DESCRIPTION
Earlier it was difficult to copy the command-to-run on the popup, but now the command-to-run text will be in text area and can be copied easily.
